### PR TITLE
Accept HTTP 201 for worker registration

### DIFF
--- a/src/V2/Worker/WorkerProtocolClient.php
+++ b/src/V2/Worker/WorkerProtocolClient.php
@@ -131,7 +131,7 @@ final class WorkerProtocolClient
             $body['max_concurrent_activity_tasks'] = $maxConcurrentActivityTasks;
         }
 
-        $response = $this->workerPost($this->workerApiPath.'/register', $body);
+        $response = $this->workerPost($this->workerApiPath.'/register', $body, allowedStatuses: [200, 201]);
 
         $this->registeredWorkerId = $workerId;
         $this->registeredTaskQueue = $taskQueue;

--- a/tests/Unit/V2/WorkerProtocolClientTest.php
+++ b/tests/Unit/V2/WorkerProtocolClientTest.php
@@ -34,7 +34,7 @@ final class WorkerProtocolClientTest extends TestCase
                 ),
             ];
 
-            return $http->response(['ok' => true, 'heartbeat_interval_seconds' => 60]);
+            return $http->response(['ok' => true, 'heartbeat_interval_seconds' => 60], 201);
         });
 
         $client = new WorkerProtocolClient($http, 'http://server:8080/', 'test-token', 'default');


### PR DESCRIPTION
Closes #386.

## Summary
- accept `201 Created` in `WorkerProtocolClient::registerWorker()`
- align the focused unit test with the standalone server's registration response

## Validation
- `docker run --rm --network host -u 1000:1000 -e DB_CONNECTION=sqlite -e DB_DATABASE=/workspace/testbench.sqlite -e REDIS_HOST=127.0.0.1 -v /home/lab/workspace-hq/repos/workflow:/workspace -w /workspace composer:2 php ./vendor/bin/phpunit tests/Unit/V2/WorkerProtocolClientTest.php`
- published-artifact polyglot rerun against `server 0.2.109`, `sdk-python 0.4.33`, `workflow 2.0.0-alpha.142`, `waterline 2.0.0-alpha.47`, and `cli 0.1.37` reproduced the PHP worker registration failure before this change and passed the four-corner smoke after applying the same one-line fix in the scratch copy
