### PR TITLE
Preserve structured replay failures for standalone workers

### DIFF
--- a/src/V2/Support/FailureFactory.php
+++ b/src/V2/Support/FailureFactory.php
@@ -249,6 +249,15 @@ final class FailureFactory
         ?int $fallbackCode = null,
     ): Throwable {
         $normalized = self::normalizePayload($payload, $fallbackClass, $fallbackMessage, $fallbackCode);
+
+        if (
+            array_key_exists('details', $normalized)
+            || is_string($normalized['details_payload_codec'] ?? null)
+            || array_key_exists('non_retryable', $normalized)
+        ) {
+            return new RestoredWorkflowException($normalized);
+        }
+
         $class = $normalized['class'];
 
         try {

--- a/tests/Unit/V2/FailureFactoryRestoreTest.php
+++ b/tests/Unit/V2/FailureFactoryRestoreTest.php
@@ -9,6 +9,8 @@ use Error;
 use Exception;
 use RuntimeException;
 use Tests\TestCase;
+use Workflow\Serializers\Serializer;
+use Workflow\V2\Exceptions\RestoredWorkflowException;
 use TypeError;
 use Workflow\V2\Support\FailureFactory;
 
@@ -67,5 +69,31 @@ final class FailureFactoryRestoreTest extends TestCase
 
         $this->assertInstanceOf(Exception::class, $restored);
         $this->assertSame('base exception sanity check', $restored->getMessage());
+    }
+
+    public function testReplayPreservesStructuredFailureMetadata(): void
+    {
+        $payload = [
+            'class' => RuntimeException::class,
+            'type' => 'planned.python.failure',
+            'message' => 'planned python failure',
+            'non_retryable' => true,
+            'details_payload_codec' => 'avro',
+            'details' => Serializer::serializeWithCodec('avro', ['label' => 'planned-python-failure']),
+        ];
+
+        $restored = FailureFactory::restoreForReplay($payload);
+
+        $this->assertInstanceOf(RestoredWorkflowException::class, $restored);
+        $this->assertSame('planned python failure', $restored->getMessage());
+        $failurePayload = $restored->failurePayload();
+
+        $this->assertSame(RuntimeException::class, $failurePayload['class'] ?? null);
+        $this->assertSame('planned.python.failure', $failurePayload['type'] ?? null);
+        $this->assertSame('planned python failure', $failurePayload['message'] ?? null);
+        $this->assertSame(0, $failurePayload['code'] ?? null);
+        $this->assertTrue($failurePayload['non_retryable'] ?? false);
+        $this->assertSame('avro', $failurePayload['details_payload_codec'] ?? null);
+        $this->assertSame($payload['details'], $failurePayload['details'] ?? null);
     }
 }


### PR DESCRIPTION
## Summary
- keep replay-time failures wrapped as RestoredWorkflowException when they carry structured durable metadata
- preserve non_retryable and details payloads instead of collapsing external worker failures to plain RuntimeException
- add a regression test covering structured replay restoration

## Validation
- docker run --rm -u 1000:1000 -v /home/lab/workspace-hq/repos/workflow:/workspace -w /workspace -e DB_CONNECTION=sqlite -e DB_DATABASE=/workspace/testbench.sqlite composer:2 php ./vendor/bin/phpunit tests/Unit/V2/FailureFactoryRestoreTest.php tests/Unit/V2/TypeRegistryTest.php

## Context
The published polyglot PHP->Python error probe now reaches the replay path on standalone PHP workers, but the structured external activity failure is currently reduced to a plain RuntimeException and loses the durable failure payload needed for cross-language inspection.