### PR TITLE
Add configurable storage connection for workflow models and migrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,34 @@ $workflow->output();
 => 'Hello, world!'
 ```
 
+## Using a dedicated storage connection
+
+By default all workflow persistence (every Eloquent model and every migration shipped
+by this package) lives on your application's **default** database connection. To isolate
+workflow state on its own database — for separate backup/retention/scaling, a different
+driver, or tenant isolation — point the package at a dedicated connection:
+
+```php
+// config/workflows.php
+'storage' => [
+    // null => the application's default connection (the default, unchanged behavior).
+    'connection' => Env::dw('DW_STORAGE_CONNECTION', 'WORKFLOW_STORAGE_CONNECTION', null),
+],
+```
+
+```dotenv
+# .env — must match a key under config('database.connections')
+DW_STORAGE_CONNECTION=durable_workflow
+```
+
+When set, both the models and the migrations are routed to that connection, so
+`php artisan migrate` creates the workflow tables there and all reads/writes target it.
+Leaving it `null` preserves today's behavior exactly.
+
+The schema/database is governed by the connection's own configuration — use
+`search_path` for PostgreSQL or `database` for MySQL on that connection. There is no
+separate schema option.
+
 ## Sponsors
 
 The Durable Workflow package is sustained by the community via sponsors and volunteers.

--- a/src/Models/StoredWorkflow.php
+++ b/src/Models/StoredWorkflow.php
@@ -13,12 +13,15 @@ use Illuminate\Support\Arr;
 use Workflow\States\HasStates;
 use Workflow\States\WorkflowContinuedStatus;
 use Workflow\States\WorkflowStatus;
+use Workflow\Traits\ResolvesStorageConnection;
 use Workflow\WorkflowMetadata;
 use Workflow\WorkflowOptions;
 use Workflow\WorkflowStub;
 
 class StoredWorkflow extends Model
 {
+    use ResolvesStorageConnection;
+
     use HasStates;
     use Prunable;
 

--- a/src/Models/StoredWorkflowException.php
+++ b/src/Models/StoredWorkflowException.php
@@ -5,9 +5,12 @@ declare(strict_types=1);
 namespace Workflow\Models;
 
 use Illuminate\Database\Eloquent\Model;
+use Workflow\Traits\ResolvesStorageConnection;
 
 class StoredWorkflowException extends Model
 {
+    use ResolvesStorageConnection;
+
     public const UPDATED_AT = null;
 
     /**

--- a/src/Models/StoredWorkflowLog.php
+++ b/src/Models/StoredWorkflowLog.php
@@ -5,9 +5,12 @@ declare(strict_types=1);
 namespace Workflow\Models;
 
 use Illuminate\Database\Eloquent\Model;
+use Workflow\Traits\ResolvesStorageConnection;
 
 class StoredWorkflowLog extends Model
 {
+    use ResolvesStorageConnection;
+
     public const UPDATED_AT = null;
 
     /**

--- a/src/Models/StoredWorkflowSignal.php
+++ b/src/Models/StoredWorkflowSignal.php
@@ -5,9 +5,12 @@ declare(strict_types=1);
 namespace Workflow\Models;
 
 use Illuminate\Database\Eloquent\Model;
+use Workflow\Traits\ResolvesStorageConnection;
 
 class StoredWorkflowSignal extends Model
 {
+    use ResolvesStorageConnection;
+
     public const UPDATED_AT = null;
 
     /**

--- a/src/Models/StoredWorkflowTimer.php
+++ b/src/Models/StoredWorkflowTimer.php
@@ -5,9 +5,12 @@ declare(strict_types=1);
 namespace Workflow\Models;
 
 use Illuminate\Database\Eloquent\Model;
+use Workflow\Traits\ResolvesStorageConnection;
 
 class StoredWorkflowTimer extends Model
 {
+    use ResolvesStorageConnection;
+
     public const UPDATED_AT = null;
 
     /**

--- a/src/Support/WorkflowMigration.php
+++ b/src/Support/WorkflowMigration.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Workflow\Support;
+
+use Illuminate\Database\Migrations\Migration;
+
+abstract class WorkflowMigration extends Migration
+{
+    public function getConnection(): ?string
+    {
+        return config('workflows.storage.connection') ?? $this->connection;
+    }
+}

--- a/src/Traits/ResolvesStorageConnection.php
+++ b/src/Traits/ResolvesStorageConnection.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Workflow\Traits;
+
+trait ResolvesStorageConnection
+{
+    public function getConnectionName(): ?string
+    {
+        return config('workflows.storage.connection') ?? $this->connection;
+    }
+}

--- a/src/V2/Models/ActivityAttempt.php
+++ b/src/V2/Models/ActivityAttempt.php
@@ -7,11 +7,14 @@ namespace Workflow\V2\Models;
 use Illuminate\Database\Eloquent\Concerns\HasUlids;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Workflow\Traits\ResolvesStorageConnection;
 use Workflow\V2\Enums\ActivityAttemptStatus;
 use Workflow\V2\Support\ConfiguredV2Models;
 
 class ActivityAttempt extends Model
 {
+    use ResolvesStorageConnection;
+
     use HasUlids;
 
     public $incrementing = false;

--- a/src/V2/Models/ActivityExecution.php
+++ b/src/V2/Models/ActivityExecution.php
@@ -9,12 +9,15 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Workflow\Serializers\Serializer;
+use Workflow\Traits\ResolvesStorageConnection;
 use Workflow\V2\Enums\ActivityStatus;
 use Workflow\V2\Support\ConfiguredV2Models;
 use Workflow\V2\Support\ExternalPayloads;
 
 class ActivityExecution extends Model
 {
+    use ResolvesStorageConnection;
+
     use HasUlids;
 
     public $incrementing = false;

--- a/src/V2/Models/WorkerCompatibilityHeartbeat.php
+++ b/src/V2/Models/WorkerCompatibilityHeartbeat.php
@@ -5,9 +5,12 @@ declare(strict_types=1);
 namespace Workflow\V2\Models;
 
 use Illuminate\Database\Eloquent\Model;
+use Workflow\Traits\ResolvesStorageConnection;
 
 class WorkerCompatibilityHeartbeat extends Model
 {
+    use ResolvesStorageConnection;
+
     protected $table = 'workflow_worker_compatibility_heartbeats';
 
     protected $guarded = [];

--- a/src/V2/Models/WorkflowChildCall.php
+++ b/src/V2/Models/WorkflowChildCall.php
@@ -6,12 +6,15 @@ namespace Workflow\V2\Models;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Workflow\Traits\ResolvesStorageConnection;
 use Workflow\V2\Enums\ChildCallStatus;
 use Workflow\V2\Enums\ParentClosePolicy;
 use Workflow\V2\Support\ConfiguredV2Models;
 
 class WorkflowChildCall extends Model
 {
+    use ResolvesStorageConnection;
+
     public $incrementing = true;
 
     protected $table = 'workflow_child_calls';

--- a/src/V2/Models/WorkflowCommand.php
+++ b/src/V2/Models/WorkflowCommand.php
@@ -10,6 +10,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\HasOne;
 use Workflow\Serializers\Serializer;
+use Workflow\Traits\ResolvesStorageConnection;
 use Workflow\V2\Enums\CommandOutcome;
 use Workflow\V2\Enums\CommandStatus;
 use Workflow\V2\Enums\CommandType;
@@ -20,6 +21,8 @@ use Workflow\V2\Support\MessageStreamCursor;
 
 class WorkflowCommand extends Model
 {
+    use ResolvesStorageConnection;
+
     use HasUlids;
 
     private const MESSAGE_COMMAND_TYPES = ['signal', 'update'];

--- a/src/V2/Models/WorkflowFailure.php
+++ b/src/V2/Models/WorkflowFailure.php
@@ -7,11 +7,14 @@ namespace Workflow\V2\Models;
 use Illuminate\Database\Eloquent\Concerns\HasUlids;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Workflow\Traits\ResolvesStorageConnection;
 use Workflow\V2\Enums\FailureCategory;
 use Workflow\V2\Support\ConfiguredV2Models;
 
 class WorkflowFailure extends Model
 {
+    use ResolvesStorageConnection;
+
     use HasUlids;
 
     public $incrementing = false;

--- a/src/V2/Models/WorkflowHistoryEvent.php
+++ b/src/V2/Models/WorkflowHistoryEvent.php
@@ -8,6 +8,7 @@ use Carbon\CarbonInterface;
 use Illuminate\Database\Eloquent\Concerns\HasUlids;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Workflow\Traits\ResolvesStorageConnection;
 use Workflow\V2\Enums\HistoryEventType;
 use Workflow\V2\Support\ConfiguredV2Models;
 use Workflow\V2\Support\ExternalPayloads;
@@ -15,6 +16,8 @@ use Workflow\V2\Support\HistoryEventPayloadContract;
 
 class WorkflowHistoryEvent extends Model
 {
+    use ResolvesStorageConnection;
+
     use HasUlids;
 
     public $incrementing = false;

--- a/src/V2/Models/WorkflowInstance.php
+++ b/src/V2/Models/WorkflowInstance.php
@@ -8,10 +8,13 @@ use Illuminate\Database\Eloquent\Concerns\HasUlids;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Workflow\Traits\ResolvesStorageConnection;
 use Workflow\V2\Support\ConfiguredV2Models;
 
 class WorkflowInstance extends Model
 {
+    use ResolvesStorageConnection;
+
     use HasUlids;
 
     public $incrementing = false;

--- a/src/V2/Models/WorkflowLink.php
+++ b/src/V2/Models/WorkflowLink.php
@@ -7,10 +7,13 @@ namespace Workflow\V2\Models;
 use Illuminate\Database\Eloquent\Concerns\HasUlids;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Workflow\Traits\ResolvesStorageConnection;
 use Workflow\V2\Support\ConfiguredV2Models;
 
 class WorkflowLink extends Model
 {
+    use ResolvesStorageConnection;
+
     use HasUlids;
 
     public $incrementing = false;

--- a/src/V2/Models/WorkflowMemo.php
+++ b/src/V2/Models/WorkflowMemo.php
@@ -7,10 +7,13 @@ namespace Workflow\V2\Models;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use InvalidArgumentException;
+use Workflow\Traits\ResolvesStorageConnection;
 use Workflow\V2\Support\ConfiguredV2Models;
 
 class WorkflowMemo extends Model
 {
+    use ResolvesStorageConnection;
+
     // Size and count limits (Phase 1 structural limits)
     public const MAX_MEMOS_PER_RUN = 100;
 

--- a/src/V2/Models/WorkflowMessage.php
+++ b/src/V2/Models/WorkflowMessage.php
@@ -6,12 +6,15 @@ namespace Workflow\V2\Models;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Workflow\Traits\ResolvesStorageConnection;
 use Workflow\V2\Enums\MessageConsumeState;
 use Workflow\V2\Enums\MessageDirection;
 use Workflow\V2\Support\ConfiguredV2Models;
 
 class WorkflowMessage extends Model
 {
+    use ResolvesStorageConnection;
+
     // Structural limits
     public const MAX_MESSAGES_PER_STREAM = 10000;
 

--- a/src/V2/Models/WorkflowRun.php
+++ b/src/V2/Models/WorkflowRun.php
@@ -11,12 +11,15 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\HasOne;
 use Workflow\Serializers\CodecRegistry;
 use Workflow\Serializers\Serializer;
+use Workflow\Traits\ResolvesStorageConnection;
 use Workflow\V2\Enums\RunStatus;
 use Workflow\V2\Support\ConfiguredV2Models;
 use Workflow\V2\Support\ExternalPayloads;
 
 class WorkflowRun extends Model
 {
+    use ResolvesStorageConnection;
+
     use HasUlids;
 
     public $incrementing = false;

--- a/src/V2/Models/WorkflowRunLineageEntry.php
+++ b/src/V2/Models/WorkflowRunLineageEntry.php
@@ -6,10 +6,13 @@ namespace Workflow\V2\Models;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Workflow\Traits\ResolvesStorageConnection;
 use Workflow\V2\Support\ConfiguredV2Models;
 
 class WorkflowRunLineageEntry extends Model
 {
+    use ResolvesStorageConnection;
+
     public $incrementing = false;
 
     protected $table = 'workflow_run_lineage_entries';

--- a/src/V2/Models/WorkflowRunSummary.php
+++ b/src/V2/Models/WorkflowRunSummary.php
@@ -7,6 +7,7 @@ namespace Workflow\V2\Models;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Workflow\Traits\ResolvesStorageConnection;
 use Workflow\V2\Enums\RunStatus;
 use Workflow\V2\Support\ConfiguredV2Models;
 use Workflow\V2\Support\RepairBlockedReason;
@@ -14,6 +15,8 @@ use Workflow\V2\Support\WorkflowTaskProblem;
 
 class WorkflowRunSummary extends Model
 {
+    use ResolvesStorageConnection;
+
     public $incrementing = false;
 
     protected $table = 'workflow_run_summaries';

--- a/src/V2/Models/WorkflowRunTimerEntry.php
+++ b/src/V2/Models/WorkflowRunTimerEntry.php
@@ -8,10 +8,13 @@ use Carbon\CarbonInterface;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Support\Carbon;
+use Workflow\Traits\ResolvesStorageConnection;
 use Workflow\V2\Support\ConfiguredV2Models;
 
 class WorkflowRunTimerEntry extends Model
 {
+    use ResolvesStorageConnection;
+
     public const CURRENT_SCHEMA_VERSION = 1;
 
     public $incrementing = false;

--- a/src/V2/Models/WorkflowRunWait.php
+++ b/src/V2/Models/WorkflowRunWait.php
@@ -8,10 +8,13 @@ use Carbon\CarbonInterface;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Support\Carbon;
+use Workflow\Traits\ResolvesStorageConnection;
 use Workflow\V2\Support\ConfiguredV2Models;
 
 class WorkflowRunWait extends Model
 {
+    use ResolvesStorageConnection;
+
     public $incrementing = false;
 
     protected $table = 'workflow_run_waits';

--- a/src/V2/Models/WorkflowSchedule.php
+++ b/src/V2/Models/WorkflowSchedule.php
@@ -11,6 +11,7 @@ use Illuminate\Database\Eloquent\Concerns\HasUlids;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Workflow\Traits\ResolvesStorageConnection;
 use Workflow\V2\Enums\ScheduleStatus;
 use Workflow\V2\Support\ConfiguredV2Models;
 
@@ -27,6 +28,8 @@ use Workflow\V2\Support\ConfiguredV2Models;
  */
 class WorkflowSchedule extends Model
 {
+    use ResolvesStorageConnection;
+
     use HasUlids;
 
     public const OVERLAP_POLICIES = [

--- a/src/V2/Models/WorkflowSchedule.php
+++ b/src/V2/Models/WorkflowSchedule.php
@@ -373,8 +373,7 @@ class WorkflowSchedule extends Model
         ?string $runId,
         string $outcome,
         ?DateTimeInterface $occurrenceTime = null,
-    ): void
-    {
+    ): void {
         $firedAt = now();
         $actions = $this->recent_actions ?? [];
 

--- a/src/V2/Models/WorkflowScheduleHistoryEvent.php
+++ b/src/V2/Models/WorkflowScheduleHistoryEvent.php
@@ -9,12 +9,15 @@ use Illuminate\Database\Eloquent\Concerns\HasUlids;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\UniqueConstraintViolationException;
+use Workflow\Traits\ResolvesStorageConnection;
 use Workflow\V2\Enums\HistoryEventType;
 use Workflow\V2\Support\ConfiguredV2Models;
 use Workflow\V2\Support\HistoryEventPayloadContract;
 
 class WorkflowScheduleHistoryEvent extends Model
 {
+    use ResolvesStorageConnection;
+
     use HasUlids;
 
     /**

--- a/src/V2/Models/WorkflowSearchAttribute.php
+++ b/src/V2/Models/WorkflowSearchAttribute.php
@@ -8,6 +8,7 @@ use Carbon\CarbonInterface;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use InvalidArgumentException;
+use Workflow\Traits\ResolvesStorageConnection;
 use Workflow\V2\Support\ConfiguredV2Models;
 
 /**
@@ -50,6 +51,8 @@ use Workflow\V2\Support\ConfiguredV2Models;
  */
 class WorkflowSearchAttribute extends Model
 {
+    use ResolvesStorageConnection;
+
     // Size limits from v2 plan
     public const MAX_ATTRIBUTES_PER_RUN = 100;
 

--- a/src/V2/Models/WorkflowService.php
+++ b/src/V2/Models/WorkflowService.php
@@ -8,10 +8,13 @@ use Illuminate\Database\Eloquent\Concerns\HasUlids;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Workflow\Traits\ResolvesStorageConnection;
 use Workflow\V2\Support\ConfiguredV2Models;
 
 class WorkflowService extends Model
 {
+    use ResolvesStorageConnection;
+
     use HasUlids;
 
     public $incrementing = false;

--- a/src/V2/Models/WorkflowServiceCall.php
+++ b/src/V2/Models/WorkflowServiceCall.php
@@ -7,11 +7,14 @@ namespace Workflow\V2\Models;
 use Illuminate\Database\Eloquent\Concerns\HasUlids;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Workflow\Traits\ResolvesStorageConnection;
 use Workflow\V2\Enums\ServiceCallOutcome;
 use Workflow\V2\Support\ConfiguredV2Models;
 
 class WorkflowServiceCall extends Model
 {
+    use ResolvesStorageConnection;
+
     use HasUlids;
 
     public $incrementing = false;

--- a/src/V2/Models/WorkflowServiceEndpoint.php
+++ b/src/V2/Models/WorkflowServiceEndpoint.php
@@ -7,10 +7,13 @@ namespace Workflow\V2\Models;
 use Illuminate\Database\Eloquent\Concerns\HasUlids;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Workflow\Traits\ResolvesStorageConnection;
 use Workflow\V2\Support\ConfiguredV2Models;
 
 class WorkflowServiceEndpoint extends Model
 {
+    use ResolvesStorageConnection;
+
     use HasUlids;
 
     public $incrementing = false;

--- a/src/V2/Models/WorkflowServiceOperation.php
+++ b/src/V2/Models/WorkflowServiceOperation.php
@@ -8,10 +8,13 @@ use Illuminate\Database\Eloquent\Concerns\HasUlids;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Workflow\Traits\ResolvesStorageConnection;
 use Workflow\V2\Support\ConfiguredV2Models;
 
 class WorkflowServiceOperation extends Model
 {
+    use ResolvesStorageConnection;
+
     use HasUlids;
 
     public $incrementing = false;

--- a/src/V2/Models/WorkflowSignal.php
+++ b/src/V2/Models/WorkflowSignal.php
@@ -8,6 +8,7 @@ use Illuminate\Database\Eloquent\Concerns\HasUlids;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Workflow\Serializers\Serializer;
+use Workflow\Traits\ResolvesStorageConnection;
 use Workflow\V2\Enums\CommandOutcome;
 use Workflow\V2\Enums\SignalStatus;
 use Workflow\V2\Support\ConfiguredV2Models;
@@ -15,6 +16,8 @@ use Workflow\V2\Support\ExternalPayloads;
 
 class WorkflowSignal extends Model
 {
+    use ResolvesStorageConnection;
+
     use HasUlids;
 
     public $incrementing = false;

--- a/src/V2/Models/WorkflowTask.php
+++ b/src/V2/Models/WorkflowTask.php
@@ -7,12 +7,15 @@ namespace Workflow\V2\Models;
 use Illuminate\Database\Eloquent\Concerns\HasUlids;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Workflow\Traits\ResolvesStorageConnection;
 use Workflow\V2\Enums\TaskStatus;
 use Workflow\V2\Enums\TaskType;
 use Workflow\V2\Support\ConfiguredV2Models;
 
 class WorkflowTask extends Model
 {
+    use ResolvesStorageConnection;
+
     use HasUlids;
 
     public $incrementing = false;

--- a/src/V2/Models/WorkflowTimelineEntry.php
+++ b/src/V2/Models/WorkflowTimelineEntry.php
@@ -7,10 +7,13 @@ namespace Workflow\V2\Models;
 use Carbon\CarbonInterface;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Workflow\Traits\ResolvesStorageConnection;
 use Workflow\V2\Support\ConfiguredV2Models;
 
 class WorkflowTimelineEntry extends Model
 {
+    use ResolvesStorageConnection;
+
     public $incrementing = false;
 
     protected $table = 'workflow_run_timeline_entries';

--- a/src/V2/Models/WorkflowTimer.php
+++ b/src/V2/Models/WorkflowTimer.php
@@ -7,11 +7,14 @@ namespace Workflow\V2\Models;
 use Illuminate\Database\Eloquent\Concerns\HasUlids;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Workflow\Traits\ResolvesStorageConnection;
 use Workflow\V2\Enums\TimerStatus;
 use Workflow\V2\Support\ConfiguredV2Models;
 
 class WorkflowTimer extends Model
 {
+    use ResolvesStorageConnection;
+
     use HasUlids;
 
     public $incrementing = false;

--- a/src/V2/Models/WorkflowUpdate.php
+++ b/src/V2/Models/WorkflowUpdate.php
@@ -10,6 +10,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Workflow\Serializers\CodecRegistry;
 use Workflow\Serializers\Serializer;
+use Workflow\Traits\ResolvesStorageConnection;
 use Workflow\V2\Enums\CommandOutcome;
 use Workflow\V2\Enums\UpdateStatus;
 use Workflow\V2\Support\ConfiguredV2Models;
@@ -17,6 +18,8 @@ use Workflow\V2\Support\ExternalPayloads;
 
 class WorkflowUpdate extends Model
 {
+    use ResolvesStorageConnection;
+
     use HasUlids;
 
     public $incrementing = false;

--- a/src/config/workflows.php
+++ b/src/config/workflows.php
@@ -406,6 +406,12 @@ return [
     // be flagged by `workflow:v2:doctor`; JSON is not a registered v2 codec.
     'serializer' => Env::dw('DW_SERIALIZER', 'WORKFLOW_SERIALIZER', 'avro'),
 
+    'storage' => [
+        // Database connection used for ALL workflow persistence (Eloquent models + migrations).
+        // null => the application's default connection (preserves existing behavior).
+        'connection' => Env::dw('DW_STORAGE_CONNECTION', 'WORKFLOW_STORAGE_CONNECTION', null),
+    ],
+
     'prune_age' => '1 month',
 
     'webhooks_route' => Env::dw('DW_WEBHOOKS_ROUTE', 'WORKFLOW_WEBHOOKS_ROUTE', 'webhooks'),

--- a/src/migrations/2022_01_01_000000_create_workflows_table.php
+++ b/src/migrations/2022_01_01_000000_create_workflows_table.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
+use Workflow\Support\WorkflowMigration;
 
-return new class() extends Migration {
+return new class() extends WorkflowMigration {
     /**
      * Run the migrations.
      */

--- a/src/migrations/2022_01_01_000001_create_workflow_logs_table.php
+++ b/src/migrations/2022_01_01_000001_create_workflow_logs_table.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
+use Workflow\Support\WorkflowMigration;
 
-return new class() extends Migration {
+return new class() extends WorkflowMigration {
     /**
      * Run the migrations.
      */

--- a/src/migrations/2022_01_01_000002_create_workflow_signals_table.php
+++ b/src/migrations/2022_01_01_000002_create_workflow_signals_table.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
+use Workflow\Support\WorkflowMigration;
 
-return new class() extends Migration {
+return new class() extends WorkflowMigration {
     /**
      * Run the migrations.
      */

--- a/src/migrations/2022_01_01_000003_create_workflow_timers_table.php
+++ b/src/migrations/2022_01_01_000003_create_workflow_timers_table.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
+use Workflow\Support\WorkflowMigration;
 
-return new class() extends Migration {
+return new class() extends WorkflowMigration {
     /**
      * Run the migrations.
      */

--- a/src/migrations/2022_01_01_000004_create_workflow_exceptions_table.php
+++ b/src/migrations/2022_01_01_000004_create_workflow_exceptions_table.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
+use Workflow\Support\WorkflowMigration;
 
-return new class() extends Migration {
+return new class() extends WorkflowMigration {
     /**
      * Run the migrations.
      */

--- a/src/migrations/2022_01_01_000005_create_workflow_relationships_table.php
+++ b/src/migrations/2022_01_01_000005_create_workflow_relationships_table.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
+use Workflow\Support\WorkflowMigration;
 
-return new class() extends Migration {
+return new class() extends WorkflowMigration {
     /**
      * Run the migrations.
      */

--- a/src/migrations/2026_04_05_000100_create_workflow_instances_table.php
+++ b/src/migrations/2026_04_05_000100_create_workflow_instances_table.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
+use Workflow\Support\WorkflowMigration;
 
-return new class() extends Migration {
+return new class() extends WorkflowMigration {
     public function up(): void
     {
         Schema::create('workflow_instances', static function (Blueprint $table): void {

--- a/src/migrations/2026_04_05_000101_create_workflow_runs_table.php
+++ b/src/migrations/2026_04_05_000101_create_workflow_runs_table.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
+use Workflow\Support\WorkflowMigration;
 
-return new class() extends Migration {
+return new class() extends WorkflowMigration {
     public function up(): void
     {
         Schema::create('workflow_runs', static function (Blueprint $table): void {

--- a/src/migrations/2026_04_05_000102_create_workflow_history_events_table.php
+++ b/src/migrations/2026_04_05_000102_create_workflow_history_events_table.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
+use Workflow\Support\WorkflowMigration;
 
-return new class() extends Migration {
+return new class() extends WorkflowMigration {
     public function up(): void
     {
         Schema::create('workflow_history_events', static function (Blueprint $table): void {

--- a/src/migrations/2026_04_05_000103_create_workflow_tasks_table.php
+++ b/src/migrations/2026_04_05_000103_create_workflow_tasks_table.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
+use Workflow\Support\WorkflowMigration;
 
-return new class() extends Migration {
+return new class() extends WorkflowMigration {
     public function up(): void
     {
         Schema::create('workflow_tasks', static function (Blueprint $table): void {

--- a/src/migrations/2026_04_05_000104_create_activity_executions_table.php
+++ b/src/migrations/2026_04_05_000104_create_activity_executions_table.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
+use Workflow\Support\WorkflowMigration;
 
-return new class() extends Migration {
+return new class() extends WorkflowMigration {
     public function up(): void
     {
         Schema::create('activity_executions', static function (Blueprint $table): void {

--- a/src/migrations/2026_04_05_000105_create_workflow_failures_table.php
+++ b/src/migrations/2026_04_05_000105_create_workflow_failures_table.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
+use Workflow\Support\WorkflowMigration;
 
-return new class() extends Migration {
+return new class() extends WorkflowMigration {
     public function up(): void
     {
         Schema::create('workflow_failures', static function (Blueprint $table): void {

--- a/src/migrations/2026_04_05_000106_create_workflow_run_summaries_table.php
+++ b/src/migrations/2026_04_05_000106_create_workflow_run_summaries_table.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
+use Workflow\Support\WorkflowMigration;
 
-return new class() extends Migration {
+return new class() extends WorkflowMigration {
     public function up(): void
     {
         Schema::create('workflow_run_summaries', static function (Blueprint $table): void {

--- a/src/migrations/2026_04_05_000107_create_workflow_run_timers_table.php
+++ b/src/migrations/2026_04_05_000107_create_workflow_run_timers_table.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
+use Workflow\Support\WorkflowMigration;
 
-return new class() extends Migration {
+return new class() extends WorkflowMigration {
     public function up(): void
     {
         Schema::create('workflow_run_timers', static function (Blueprint $table): void {

--- a/src/migrations/2026_04_05_000108_create_workflow_commands_table.php
+++ b/src/migrations/2026_04_05_000108_create_workflow_commands_table.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
+use Workflow\Support\WorkflowMigration;
 
-return new class() extends Migration {
+return new class() extends WorkflowMigration {
     public function up(): void
     {
         Schema::create('workflow_commands', static function (Blueprint $table): void {

--- a/src/migrations/2026_04_05_000112_create_workflow_links_table.php
+++ b/src/migrations/2026_04_05_000112_create_workflow_links_table.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
+use Workflow\Support\WorkflowMigration;
 
-return new class() extends Migration {
+return new class() extends WorkflowMigration {
     public function up(): void
     {
         Schema::create('workflow_links', static function (Blueprint $table): void {

--- a/src/migrations/2026_04_08_000124_create_activity_attempts_table.php
+++ b/src/migrations/2026_04_08_000124_create_activity_attempts_table.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
+use Workflow\Support\WorkflowMigration;
 
-return new class() extends Migration {
+return new class() extends WorkflowMigration {
     public function up(): void
     {
         Schema::create('activity_attempts', static function (Blueprint $table): void {

--- a/src/migrations/2026_04_08_000126_create_worker_compatibility_heartbeats_table.php
+++ b/src/migrations/2026_04_08_000126_create_worker_compatibility_heartbeats_table.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
+use Workflow\Support\WorkflowMigration;
 
-return new class() extends Migration {
+return new class() extends WorkflowMigration {
     public function up(): void
     {
         Schema::create('workflow_worker_compatibility_heartbeats', static function (Blueprint $table): void {

--- a/src/migrations/2026_04_09_000128_create_workflow_updates_table.php
+++ b/src/migrations/2026_04_09_000128_create_workflow_updates_table.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
+use Workflow\Support\WorkflowMigration;
 
-return new class() extends Migration {
+return new class() extends WorkflowMigration {
     public function up(): void
     {
         Schema::create('workflow_updates', static function (Blueprint $table): void {

--- a/src/migrations/2026_04_09_000130_create_workflow_signal_records_table.php
+++ b/src/migrations/2026_04_09_000130_create_workflow_signal_records_table.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
+use Workflow\Support\WorkflowMigration;
 
-return new class() extends Migration {
+return new class() extends WorkflowMigration {
     public function up(): void
     {
         Schema::create('workflow_signal_records', static function (Blueprint $table): void {

--- a/src/migrations/2026_04_10_000136_create_workflow_run_waits_table.php
+++ b/src/migrations/2026_04_10_000136_create_workflow_run_waits_table.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
+use Workflow\Support\WorkflowMigration;
 
-return new class() extends Migration {
+return new class() extends WorkflowMigration {
     public function up(): void
     {
         Schema::create('workflow_run_waits', static function (Blueprint $table): void {

--- a/src/migrations/2026_04_10_000137_create_workflow_run_timeline_entries_table.php
+++ b/src/migrations/2026_04_10_000137_create_workflow_run_timeline_entries_table.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
+use Workflow\Support\WorkflowMigration;
 
-return new class() extends Migration {
+return new class() extends WorkflowMigration {
     public function up(): void
     {
         Schema::create('workflow_run_timeline_entries', static function (Blueprint $table): void {

--- a/src/migrations/2026_04_10_000139_create_workflow_run_lineage_entries_table.php
+++ b/src/migrations/2026_04_10_000139_create_workflow_run_lineage_entries_table.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
+use Workflow\Support\WorkflowMigration;
 
-return new class() extends Migration {
+return new class() extends WorkflowMigration {
     public function up(): void
     {
         Schema::create('workflow_run_lineage_entries', static function (Blueprint $table): void {

--- a/src/migrations/2026_04_11_000140_create_workflow_run_timer_entries_table.php
+++ b/src/migrations/2026_04_11_000140_create_workflow_run_timer_entries_table.php
@@ -2,12 +2,12 @@
 
 declare(strict_types=1);
 
-use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
+use Workflow\Support\WorkflowMigration;
 use Workflow\V2\Models\WorkflowRunTimerEntry;
 
-return new class() extends Migration {
+return new class() extends WorkflowMigration {
     public function up(): void
     {
         Schema::create('workflow_run_timer_entries', static function (Blueprint $table): void {

--- a/src/migrations/2026_04_14_000157_create_workflow_schedules_table.php
+++ b/src/migrations/2026_04_14_000157_create_workflow_schedules_table.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
+use Workflow\Support\WorkflowMigration;
 
-return new class() extends Migration {
+return new class() extends WorkflowMigration {
     public function up(): void
     {
         Schema::create('workflow_schedules', static function (Blueprint $table): void {

--- a/src/migrations/2026_04_15_000150_create_workflow_search_attributes_table.php
+++ b/src/migrations/2026_04_15_000150_create_workflow_search_attributes_table.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
+use Workflow\Support\WorkflowMigration;
 
-return new class() extends Migration {
+return new class() extends WorkflowMigration {
     /**
      * Create workflow_search_attributes table for typed indexed metadata.
      *

--- a/src/migrations/2026_04_16_000151_create_workflow_memos_table.php
+++ b/src/migrations/2026_04_16_000151_create_workflow_memos_table.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
+use Workflow\Support\WorkflowMigration;
 
-return new class() extends Migration {
+return new class() extends WorkflowMigration {
     public function up(): void
     {
         Schema::create('workflow_memos', static function (Blueprint $table): void {

--- a/src/migrations/2026_04_16_000160_create_workflow_messages_table.php
+++ b/src/migrations/2026_04_16_000160_create_workflow_messages_table.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
+use Workflow\Support\WorkflowMigration;
 
-return new class() extends Migration {
+return new class() extends WorkflowMigration {
     public function up(): void
     {
         Schema::create('workflow_messages', static function (Blueprint $table): void {

--- a/src/migrations/2026_04_16_000170_create_workflow_child_calls_table.php
+++ b/src/migrations/2026_04_16_000170_create_workflow_child_calls_table.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
+use Workflow\Support\WorkflowMigration;
 
-return new class() extends Migration {
+return new class() extends WorkflowMigration {
     public function up(): void
     {
         Schema::create('workflow_child_calls', static function (Blueprint $table): void {

--- a/src/migrations/2026_04_16_000180_create_workflow_schedule_history_events_table.php
+++ b/src/migrations/2026_04_16_000180_create_workflow_schedule_history_events_table.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
+use Workflow\Support\WorkflowMigration;
 
-return new class() extends Migration {
+return new class() extends WorkflowMigration {
     private const TABLE = 'workflow_schedule_history_events';
 
     private const WORKFLOW_SCHEDULE_INDEX = 'wf_schedule_history_workflow_schedule_idx';

--- a/src/migrations/2026_04_24_000190_create_workflow_service_endpoints_table.php
+++ b/src/migrations/2026_04_24_000190_create_workflow_service_endpoints_table.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
+use Workflow\Support\WorkflowMigration;
 
-return new class() extends Migration {
+return new class() extends WorkflowMigration {
     private const TABLE = 'workflow_service_endpoints';
 
     private const NAMESPACE_INDEX = 'wf_service_endpoints_namespace_idx';

--- a/src/migrations/2026_04_24_000191_create_workflow_services_table.php
+++ b/src/migrations/2026_04_24_000191_create_workflow_services_table.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
+use Workflow\Support\WorkflowMigration;
 
-return new class() extends Migration {
+return new class() extends WorkflowMigration {
     private const TABLE = 'workflow_services';
 
     private const ENDPOINT_INDEX = 'wf_services_endpoint_idx';

--- a/src/migrations/2026_04_24_000192_create_workflow_service_operations_table.php
+++ b/src/migrations/2026_04_24_000192_create_workflow_service_operations_table.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
+use Workflow\Support\WorkflowMigration;
 
-return new class() extends Migration {
+return new class() extends WorkflowMigration {
     private const TABLE = 'workflow_service_operations';
 
     private const ENDPOINT_INDEX = 'wf_service_ops_endpoint_idx';

--- a/src/migrations/2026_04_24_000193_create_workflow_service_calls_table.php
+++ b/src/migrations/2026_04_24_000193_create_workflow_service_calls_table.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
+use Workflow\Support\WorkflowMigration;
 
-return new class() extends Migration {
+return new class() extends WorkflowMigration {
     private const TABLE = 'workflow_service_calls';
 
     private const ENDPOINT_INDEX = 'wf_service_calls_endpoint_idx';

--- a/src/migrations/2026_05_05_000200_add_embedded_import_markers_to_workflow_runs.php
+++ b/src/migrations/2026_05_05_000200_add_embedded_import_markers_to_workflow_runs.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
+use Workflow\Support\WorkflowMigration;
 
-return new class() extends Migration {
+return new class() extends WorkflowMigration {
     public function up(): void
     {
         Schema::table('workflow_runs', static function (Blueprint $table): void {

--- a/src/migrations/2026_05_05_000590_add_sticky_execution_columns.php
+++ b/src/migrations/2026_05_05_000590_add_sticky_execution_columns.php
@@ -1,10 +1,10 @@
 <?php
 
-use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
+use Workflow\Support\WorkflowMigration;
 
-return new class() extends Migration {
+return new class() extends WorkflowMigration {
     public function up(): void
     {
         Schema::table('workflow_runs', function (Blueprint $table): void {

--- a/src/migrations/2026_05_05_000590_add_sticky_execution_columns.php
+++ b/src/migrations/2026_05_05_000590_add_sticky_execution_columns.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 use Workflow\Support\WorkflowMigration;
@@ -7,7 +9,7 @@ use Workflow\Support\WorkflowMigration;
 return new class() extends WorkflowMigration {
     public function up(): void
     {
-        Schema::table('workflow_runs', function (Blueprint $table): void {
+        Schema::table('workflow_runs', static function (Blueprint $table): void {
             if (! Schema::hasColumn('workflow_runs', 'sticky_worker_id')) {
                 $table->string('sticky_worker_id')
                     ->nullable()
@@ -21,7 +23,7 @@ return new class() extends WorkflowMigration {
             }
         });
 
-        Schema::table('workflow_tasks', function (Blueprint $table): void {
+        Schema::table('workflow_tasks', static function (Blueprint $table): void {
             if (! Schema::hasColumn('workflow_tasks', 'sticky_worker_id')) {
                 $table->string('sticky_worker_id')
                     ->nullable()
@@ -50,7 +52,7 @@ return new class() extends WorkflowMigration {
 
     public function down(): void
     {
-        Schema::table('workflow_tasks', function (Blueprint $table): void {
+        Schema::table('workflow_tasks', static function (Blueprint $table): void {
             foreach (['sticky_worker_id', 'sticky_until', 'sticky_replay_mode', 'sticky_claimed_at'] as $column) {
                 if (Schema::hasColumn('workflow_tasks', $column)) {
                     $table->dropColumn($column);
@@ -58,7 +60,7 @@ return new class() extends WorkflowMigration {
             }
         });
 
-        Schema::table('workflow_runs', function (Blueprint $table): void {
+        Schema::table('workflow_runs', static function (Blueprint $table): void {
             foreach (['sticky_worker_id', 'sticky_until'] as $column) {
                 if (Schema::hasColumn('workflow_runs', $column)) {
                     $table->dropColumn($column);

--- a/src/migrations/2026_05_08_000200_add_history_budget_pressure_to_workflow_run_summaries.php
+++ b/src/migrations/2026_05_08_000200_add_history_budget_pressure_to_workflow_run_summaries.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
+use Workflow\Support\WorkflowMigration;
 
-return new class() extends Migration {
+return new class() extends WorkflowMigration {
     public function up(): void
     {
         Schema::table('workflow_run_summaries', static function (Blueprint $table): void {

--- a/src/migrations/2026_05_08_000200_add_history_budget_pressure_to_workflow_run_summaries.php
+++ b/src/migrations/2026_05_08_000200_add_history_budget_pressure_to_workflow_run_summaries.php
@@ -24,10 +24,7 @@ return new class() extends WorkflowMigration {
     {
         Schema::table('workflow_run_summaries', static function (Blueprint $table): void {
             $table->dropIndex('workflow_run_summaries_history_budget_pressure_index');
-            $table->dropColumn([
-                'history_fan_out',
-                'history_budget_pressure',
-            ]);
+            $table->dropColumn(['history_fan_out', 'history_budget_pressure']);
         });
     }
 };

--- a/src/migrations/2026_05_09_000300_add_priority_and_fairness_to_workflow_tasks.php
+++ b/src/migrations/2026_05_09_000300_add_priority_and_fairness_to_workflow_tasks.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
+use Workflow\Support\WorkflowMigration;
 
-return new class() extends Migration {
+return new class() extends WorkflowMigration {
     public function up(): void
     {
         Schema::table('workflow_runs', static function (Blueprint $table): void {

--- a/src/migrations/2026_05_09_000300_add_priority_and_fairness_to_workflow_tasks.php
+++ b/src/migrations/2026_05_09_000300_add_priority_and_fairness_to_workflow_tasks.php
@@ -32,14 +32,8 @@ return new class() extends WorkflowMigration {
                 ->default(1)
                 ->after('fairness_key');
 
-            $table->index(
-                ['queue', 'status', 'priority', 'available_at'],
-                'workflow_tasks_dispatch_order_index',
-            );
-            $table->index(
-                ['queue', 'status', 'fairness_key'],
-                'workflow_tasks_fairness_class_index',
-            );
+            $table->index(['queue', 'status', 'priority', 'available_at'], 'workflow_tasks_dispatch_order_index');
+            $table->index(['queue', 'status', 'fairness_key'], 'workflow_tasks_fairness_class_index');
         });
     }
 

--- a/src/migrations/2026_05_20_000100_add_keyword_list_to_workflow_search_attributes.php
+++ b/src/migrations/2026_05_20_000100_add_keyword_list_to_workflow_search_attributes.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
+use Workflow\Support\WorkflowMigration;
 
-return new class() extends Migration {
+return new class() extends WorkflowMigration {
     public function up(): void
     {
         Schema::table('workflow_search_attributes', static function (Blueprint $table): void {

--- a/tests/Unit/StorageConnectionTest.php
+++ b/tests/Unit/StorageConnectionTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use Tests\TestCase;
+use Workflow\Models\StoredWorkflow;
+use Workflow\V2\Models\WorkflowMessage;
+use Workflow\V2\Models\WorkflowRun;
+
+final class StorageConnectionTest extends TestCase
+{
+    public function testModelsResolveConfiguredStorageConnection(): void
+    {
+        config([
+            'workflows.storage.connection' => 'secondary',
+        ]);
+
+        // StoredWorkflow (v1), WorkflowRun (v2 resolve-path) and WorkflowMessage
+        // (v2 hardcoded-usage) all route through the same trait, so the
+        // hardcoded and ConfiguredV2Models::resolve() call sites agree.
+        $this->assertSame('secondary', (new StoredWorkflow())->getConnectionName());
+        $this->assertSame('secondary', (new WorkflowRun())->getConnectionName());
+        $this->assertSame('secondary', (new WorkflowMessage())->getConnectionName());
+    }
+
+    public function testModelsFallBackToDefaultConnectionWhenUnset(): void
+    {
+        config([
+            'workflows.storage.connection' => null,
+        ]);
+
+        // null config preserves the historical behavior: the model reports its
+        // own connection (null => the application's default connection).
+        $this->assertNull((new StoredWorkflow())->getConnectionName());
+        $this->assertNull((new WorkflowRun())->getConnectionName());
+        $this->assertNull((new WorkflowMessage())->getConnectionName());
+    }
+}

--- a/tests/Unit/migrations/MigrationsTest.php
+++ b/tests/Unit/migrations/MigrationsTest.php
@@ -69,6 +69,44 @@ final class MigrationsTest extends TestCase
     }
 
     /**
+     * Every package migration must extend Workflow\Support\WorkflowMigration
+     * so it honors the configurable workflows.storage.connection. The default
+     * `php artisan make:migration` output extends the framework's bare
+     * Illuminate\Database\Migrations\Migration, which silently lands the
+     * workflow tables on the application's default connection. This contract
+     * fails closed when a newly generated migration forgets the swap.
+     */
+    public function testEveryPackageMigrationExtendsWorkflowMigrationBase(): void
+    {
+        $files = glob(dirname(__DIR__, 3) . '/src/migrations/*.php') ?: [];
+
+        $this->assertNotEmpty($files);
+
+        $violations = [];
+
+        foreach ($files as $file) {
+            $contents = file_get_contents($file);
+
+            $this->assertIsString($contents);
+
+            if (! str_contains($contents, 'extends WorkflowMigration')) {
+                $violations[] = basename($file) . ' does not extend WorkflowMigration';
+            }
+
+            if (preg_match('/extends\s+Migration\b/', $contents) === 1) {
+                $violations[] = basename($file) . ' still extends the framework Migration base';
+            }
+        }
+
+        $this->assertSame(
+            [],
+            $violations,
+            'Every package migration must extend Workflow\Support\WorkflowMigration so it '
+            . 'honors workflows.storage.connection (regenerate with the package base class).',
+        );
+    }
+
+    /**
      * Mirrors `App\Support\MigrationAdoption::createdTablesIn()` in the
      * `durableworkflow/server` package. That class drives BLK-S002 recovery
      * by scanning each pending package migration's `Schema::create()` target

--- a/tests/Unit/migrations/StorageConnectionMigrationTest.php
+++ b/tests/Unit/migrations/StorageConnectionMigrationTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Migrations;
+
+use Illuminate\Support\Facades\Schema;
+use Tests\TestCase;
+
+final class StorageConnectionMigrationTest extends TestCase
+{
+    private string $secondaryDatabase = '';
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+
+        if ($this->secondaryDatabase !== '' && is_file($this->secondaryDatabase)) {
+            @unlink($this->secondaryDatabase);
+        }
+    }
+
+    public function testWorkflowMigrationsRunOnConfiguredStorageConnection(): void
+    {
+        $default = (string) config('database.default');
+
+        $this->assertNotSame('secondary', $default);
+
+        foreach (['workflows', 'workflow_runs', 'workflow_messages'] as $table) {
+            $this->assertTrue(
+                Schema::connection('secondary')->hasTable($table),
+                "Expected the {$table} table to be created on the secondary connection.",
+            );
+
+            $this->assertFalse(
+                Schema::connection($default)->hasTable($table),
+                "Did not expect the {$table} table on the default connection.",
+            );
+        }
+    }
+
+    protected function defineEnvironment($app): void
+    {
+        $this->secondaryDatabase = (string) tempnam(sys_get_temp_dir(), 'wf_storage_');
+
+        $app['config']->set('database.connections.secondary', [
+            'driver' => 'sqlite',
+            'database' => $this->secondaryDatabase,
+            'prefix' => '',
+            'foreign_key_constraints' => false,
+        ]);
+
+        // Route every workflow model and migration to the secondary connection
+        // for the lifetime of this test class.
+        $app['config']->set('workflows.storage.connection', 'secondary');
+    }
+}


### PR DESCRIPTION
# Add configurable storage connection for workflow models and migrations

## Summary

This adds an optional `workflows.storage.connection` config key that routes **all**
workflow persistence — every Eloquent model under `src/Models/` and `src/V2/Models/`, and
every migration under `src/migrations/` — to a dedicated database connection. The key
defaults to `null`, which resolves to the application's default connection, so existing
deployments are **fully backward compatible** and see no behavior change.

## Motivation

We want workflow state to live in a separate `durable_workflow` database, isolated from our
central/tenant OLTP databases, across both MariaDB and PostgreSQL. Today the package gives no
supported way to do that:

- **No connection hook on the models.** Every model in `src/Models/` and `src/V2/Models/`
  extends `Illuminate\Database\Eloquent\Model` directly and never overrides
  `getConnectionName()`, so workflow storage always lands on the application's *default*
  connection.
- **Consumer-side model swaps cannot route everything, and would split-brain.** The
  `ConfiguredV2Models::resolve('*_model', …)` mechanism only covers *some* models. Several
  tables are also reached through **hardcoded** class references (e.g. `new WorkflowMessage()`,
  `WorkflowChildCall::`, `WorkerCompatibilityHeartbeat::`) alongside the `resolve()` path.
  Overriding a model only on the `resolve()` side would leave the hardcoded call sites on the
  default connection — the *same table* read on two connections (a split-brain). The only
  correct place to route the connection is the model class itself.
- **Routing the store is an industry-standard capability.** Telescope
  (`telescope.storage.database.connection`), Horizon, Passport, and
  `spatie/laravel-activitylog` (`activitylog.database_connection`) all expose this. A durable
  workflow engine — the system of record for critical long-running processes — benefits even
  more from isolating its store: independent backup/retention/scaling, multi-driver setups,
  and tenant isolation.

## What changed

- **Config key** — a new top-level `storage` block in `src/config/workflows.php`:
  ```php
  'storage' => [
      'connection' => Env::dw('DW_STORAGE_CONNECTION', 'WORKFLOW_STORAGE_CONNECTION', null),
  ],
  ```
  It uses the existing `DW_*` → `WORKFLOW_*` → default env contract.
- **`Workflow\Traits\ResolvesStorageConnection`** — a small trait that overrides
  `getConnectionName()` to return `config('workflows.storage.connection') ?? $this->connection`.
  Applied to all 33 models. Because the routing lives on the model class, both hardcoded and
  `resolve()`-based usages resolve to the same connection — eliminating the split-brain.
- **`Workflow\Support\WorkflowMigration`** — an abstract `Migration` subclass that overrides
  `getConnection()` the same way. All 39 migrations now extend it instead of
  `Illuminate\Database\Migrations\Migration`.
- **Tests** — model connection resolution (incl. backward-compatible null fallback),
  migration routing onto a second connection, and a fail-closed contract test that every
  package migration extends `WorkflowMigration`.
- **Docs** — a "Using a dedicated storage connection" section in the README.

## Backward compatibility

The key defaults to `null`. With `null`, `getConnectionName()` / `getConnection()` return the
model's own `$connection` (also `null`), i.e. the application's default connection — exactly
today's behavior. Existing apps are unaffected; no migration or config change is required.

## How it works

For migrations the routing relies on Laravel's `Migrator`: `runMigration()` resolves the
connection from `$migration->getConnection()` (overriding the `--database` option), and
`runMethod()` temporarily sets that connection as the default for the duration of `up()` /
`down()`. That is why the bare `Schema::create(...)` / `Schema::dropIfExists(...)` calls need
no change — they land on the configured connection automatically. The migration repository
rows still record on the run connection, which is standard Laravel behavior (the same as
Telescope).

## Testing

- `Tests\Unit\StorageConnectionTest` — with `workflows.storage.connection = 'secondary'`,
  asserts `getConnectionName() === 'secondary'` for `StoredWorkflow` (v1),
  `WorkflowRun` (v2 resolve-path) and `WorkflowMessage` (v2 hardcoded-usage); with the key
  unset, asserts the null/default fallback.
- `Tests\Unit\Migrations\StorageConnectionMigrationTest` — registers a second `sqlite`
  connection, points `workflows.storage.connection` at it, runs the migrations, then asserts
  representative workflow tables (`workflows`, `workflow_runs`, `workflow_messages`) exist on
  the secondary connection and are absent on the default connection.
- `Tests\Unit\Migrations\MigrationsTest::testEveryPackageMigrationExtendsWorkflowMigrationBase`
  — a fail-closed contract test (matching the existing migration-slate contracts) asserting
  every `src/migrations/*.php` extends `WorkflowMigration` and none extends the framework's
  bare `Migration`. This guards against a future `make:migration` regenerating a migration on
  the default base class and silently bypassing the storage-connection routing.
