### PR TITLE
Route raw workflow queries through the configured storage connection

### DIFF
--- a/src/Commands/V1ListCommand.php
+++ b/src/Commands/V1ListCommand.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace Workflow\Commands;
 
 use Illuminate\Console\Command;
-use Illuminate\Support\Facades\DB;
 use Symfony\Component\Console\Helper\Table;
+use Workflow\Models\StoredWorkflow;
 
 class V1ListCommand extends Command
 {
@@ -18,7 +18,10 @@ class V1ListCommand extends Command
 
     public function handle(): int
     {
-        $query = DB::table('workflows')
+        $storedWorkflow = new StoredWorkflow();
+
+        $query = $storedWorkflow->getConnection()
+            ->table($storedWorkflow->getTable())
             ->whereNotIn('status', ['completed', 'failed', 'cancelled']);
 
         $status = $this->option('status');

--- a/src/V2/Support/CommandSequence.php
+++ b/src/V2/Support/CommandSequence.php
@@ -4,7 +4,8 @@ declare(strict_types=1);
 
 namespace Workflow\V2\Support;
 
-use Illuminate\Support\Facades\DB;
+use Illuminate\Database\Query\Builder;
+use Workflow\V2\Models\WorkflowCommand;
 use Workflow\V2\Models\WorkflowRun;
 
 final class CommandSequence
@@ -28,7 +29,7 @@ final class CommandSequence
 
     private static function ensureBackfilled(WorkflowRun $run): int
     {
-        $commandQuery = DB::table('workflow_commands')
+        $commandQuery = self::commandsTable()
             ->where('workflow_run_id', $run->id);
 
         $maxSequence = (int) ($commandQuery->max('command_sequence') ?? 0);
@@ -54,7 +55,7 @@ final class CommandSequence
     private static function backfill(WorkflowRun $run): int
     {
         $sequence = 0;
-        $commands = DB::table('workflow_commands')
+        $commands = self::commandsTable()
             ->select(['id', 'command_sequence'])
             ->where('workflow_run_id', $run->id)
             ->orderBy('created_at')
@@ -69,7 +70,7 @@ final class CommandSequence
                 continue;
             }
 
-            DB::table('workflow_commands')
+            self::commandsTable()
                 ->where('id', $command->id)
                 ->update([
                     'command_sequence' => $sequence,
@@ -81,5 +82,16 @@ final class CommandSequence
         ])->save();
 
         return $sequence;
+    }
+
+    private static function commandsTable(): Builder
+    {
+        $model = ConfiguredV2Models::resolve('command_model', WorkflowCommand::class);
+
+        /** @var WorkflowCommand $command */
+        $command = new $model();
+
+        return $command->getConnection()
+            ->table($command->getTable());
     }
 }

--- a/tests/Unit/CommandSequenceStorageConnectionTest.php
+++ b/tests/Unit/CommandSequenceStorageConnectionTest.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use Illuminate\Support\Str;
+use Tests\TestCase;
+use Workflow\V2\Enums\RunStatus;
+use Workflow\V2\Models\WorkflowRun;
+use Workflow\V2\Support\CommandSequence;
+
+final class CommandSequenceStorageConnectionTest extends TestCase
+{
+    private string $secondaryDatabase = '';
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+
+        if ($this->secondaryDatabase !== '' && is_file($this->secondaryDatabase)) {
+            @unlink($this->secondaryDatabase);
+        }
+    }
+
+    public function testReserveNextResolvesCommandQueriesOnStorageConnection(): void
+    {
+        $default = (string) config('database.default');
+
+        $this->assertNotSame('secondary', $default);
+
+        // In this environment the workflow tables only exist on the secondary
+        // (storage) connection; the WorkflowRun resolves there via the
+        // ResolvesStorageConnection trait.
+        $run = WorkflowRun::create([
+            'workflow_instance_id' => (string) Str::ulid(),
+            'run_number' => 1,
+            'workflow_class' => 'Tests\\Unit\\DummyWorkflow',
+            'workflow_type' => 'dummy',
+            'status' => RunStatus::Running,
+            'last_command_sequence' => 0,
+        ]);
+
+        // Before the fix CommandSequence read/wrote the command sequence through
+        // DB::table('workflow_commands'), which targets the application's default
+        // connection — where the workflow_commands table does not exist — and
+        // throws "no such table". Routing through the command model's connection
+        // keeps these maintenance queries on the configured storage connection.
+        $sequence = CommandSequence::reserveNext($run);
+
+        $this->assertSame(1, $sequence);
+        $this->assertSame(1, (int) $run->fresh()->last_command_sequence);
+    }
+
+    protected function defineEnvironment($app): void
+    {
+        $this->secondaryDatabase = (string) tempnam(sys_get_temp_dir(), 'wf_storage_');
+
+        $app['config']->set('database.connections.secondary', [
+            'driver' => 'sqlite',
+            'database' => $this->secondaryDatabase,
+            'prefix' => '',
+            'foreign_key_constraints' => false,
+        ]);
+
+        // Route every workflow model and migration to the secondary connection
+        // for the lifetime of this test class.
+        $app['config']->set('workflows.storage.connection', 'secondary');
+    }
+}


### PR DESCRIPTION
## Summary

`CommandSequence` (v2 command-sequence reservation) and the `workflow:v1:list`
command read and wrote workflow tables through `DB::table('...')`, which always
targets the application's **default** database connection. This bypasses the
`workflows.storage.connection` routing added in #391, so whenever workflow state
lives on a dedicated connection these call sites silently hit the wrong database.
This PR routes those raw queries through the model's resolved connection and adds
a fail-closed regression test.

## Root cause

#391 made all workflow persistence connection-aware: every Eloquent model honors
`workflows.storage.connection` through the `ResolvesStorageConnection` trait, and
every migration extends `WorkflowMigration`. The routing intentionally lives on
the model class so that both `ConfiguredV2Models::resolve()` and hardcoded model
references agree on a single connection (no split-brain).

Two code paths reach workflow tables through the **raw query builder** instead of
a model, so they never picked up that routing:

- `src/V2/Support/CommandSequence.php` — `ensureBackfilled()` / `backfill()` use
  `DB::table('workflow_commands')` (3 call sites) to read and renumber the command
  sequence for a run.
- `src/Commands/V1ListCommand.php` — `DB::table('workflows')` to list active v1
  workflows.

`DB::table('workflow_commands')` resolves the **default** connection. When
`workflows.storage.connection` points at a separate database (the entire purpose
of the key), the `WorkflowRun` / `WorkflowCommand` models route to the storage
connection while these raw queries go to the default one. In practice that throws:

```
PDOException: SQLSTATE[HY000]: General error: 1 no such table: workflow_commands
```

because the workflow tables only exist on the storage connection — or, where a
default-connection copy happens to exist, it reads/writes a stale store
(split-brain). `CommandSequence::reserveNext()` is on the hot path for starting a
workflow step, so this blocks v2 execution entirely on any dedicated-storage
deployment.

## What changed

- **`CommandSequence`** — a private `commandsTable()` helper returns a query
  builder bound to the configured command model's own connection and table
  (`$command->getConnection()->table($command->getTable())`). The three
  `DB::table('workflow_commands')` call sites now go through it.
- **`V1ListCommand`** — the listing query is built from the v1 model's resolved
  connection and table (`$storedWorkflow->getConnection()->table($storedWorkflow->getTable())`).

Both follow the connection-from-the-model pattern already used by
`WaterlineEngineSource` (`DB::connection($model->getConnectionName())`), keeping a
single source of truth for where workflow data lives.

## Backward compatibility

When `workflows.storage.connection` is unset (the default, `null`), the models
resolve to the application's default connection and their existing table names
(`workflow_commands`, `workflows`) — identical to the previous `DB::table()`
behavior. No config or migration change is required, and the default-connection
command-sequence path is covered by the existing v2 unit tests, which continue to
pass unchanged.