### PR TITLE
Fix route:cache failing on signal webhook routes (Serialization of 'ReflectionMethod' is not allowed)

### DIFF
--- a/src/Webhooks.php
+++ b/src/Webhooks.php
@@ -95,18 +95,19 @@ class Webhooks
         foreach (self::getSignalMethods($workflow) as $method) {
             if (self::hasWebhookAttributeOnMethod($method)) {
                 $slug = Str::kebab(class_basename($workflow));
-                $signal = Str::kebab($method->getName());
+                $signalMethod = $method->getName();
+                $signal = Str::kebab($signalMethod);
                 Route::post(
                     "{$basePath}/signal/{$slug}/{workflowId}/{$signal}",
-                    static function (Request $request, $workflowId) use ($workflow, $method) {
+                    static function (Request $request, $workflowId) use ($workflow, $signalMethod) {
                         $request = self::validateAuth($request);
                         $workflowInstance = WorkflowStub::load($workflowId);
                         $params = self::resolveNamedParameters(
                             $workflow,
-                            $method->getName(),
+                            $signalMethod,
                             $request->except('workflowId')
                         );
-                        $workflowInstance->{$method->getName()}(...$params);
+                        $workflowInstance->{$signalMethod}(...$params);
                         return response()->json([
                             'message' => 'Signal sent',
                         ]);

--- a/tests/Unit/WebhooksTest.php
+++ b/tests/Unit/WebhooksTest.php
@@ -391,6 +391,26 @@ final class WebhooksTest extends TestCase
             'message' => 'Unauthorized',
         ]);
     }
+
+    public function testWebhookRoutesCanBeSerializedForRouteCaching()
+    {
+        $webhookRoutes = [];
+
+        foreach (Route::getRoutes() as $route) {
+            if (str_starts_with((string) $route->getName(), 'workflows.')) {
+                $webhookRoutes[] = $route;
+            }
+        }
+
+        $this->assertNotEmpty($webhookRoutes);
+
+        foreach ($webhookRoutes as $route) {
+            // Mirrors what `php artisan route:cache` does. Closures must only
+            // capture serializable values (no ReflectionMethod instances).
+            $route->prepareForSerialization();
+            serialize($route);
+        }
+    }
 }
 
 class TestClass


### PR DESCRIPTION
## Problem

With any workflow that has a `#[SignalMethod]` + `#[Webhook]` method registered via `Webhooks::routes()`, `php artisan route:cache` fails:

```
Exception: Serialization of 'ReflectionMethod' is not allowed
```

Laravel serializes closure-based routes with `SerializableClosure` (all supported versions, 9 through 13, do this in `Route::prepareForSerialization()`), which serializes the closure's captured variables. The signal webhook closure captures the `ReflectionMethod` instance:

```php
static function (Request $request, $workflowId) use ($workflow, $method) {
```

and PHP refuses to serialize reflection objects. Since `route:cache`/`optimize` runs in most production deploys, adding the first `#[Webhook]` signal method breaks deployment. The start webhook closure is fine — it only captures the class-name string.

## Fix

Capture the method name (a string) instead of the `ReflectionMethod`; the closure only ever used `$method->getName()`.

## Test

`testWebhookRoutesCanBeSerializedForRouteCaching` mirrors what `route:cache` does (`prepareForSerialization()` + `serialize()` on each registered webhook route). It fails on master with the exception above and passes with this change.

Note: the `v2` branch has the same capture in its `src/Webhooks.php`, so this is worth porting there too.

