### PR TITLE
Speed up Psalm analysis of activity and workflow jobs

### DIFF
--- a/src/Activity.php
+++ b/src/Activity.php
@@ -57,19 +57,12 @@ class Activity implements ShouldBeEncrypted, ShouldBeUnique, ShouldQueue
         $options = $this->storedWorkflow->workflowOptions();
         $connection = $options->connection;
 
-        if ($connection !== null) {
-            $this->onConnection($connection);
-        } elseif (property_exists($this, 'connection')) {
-            $this->onConnection($this->connection);
-        }
+        // Give Psalm a base-typed receiver so Queueable is analyzed once per job base class.
+        self::initializeConnection($this, $connection);
 
         $queue = $options->queue;
 
-        if ($queue !== null) {
-            $this->onQueue($queue);
-        } elseif (property_exists($this, 'queue')) {
-            $this->onQueue($this->queue);
-        }
+        self::initializeQueue($this, $queue);
 
         $this->afterCommit = true;
     }
@@ -180,6 +173,24 @@ class Activity implements ShouldBeEncrypted, ShouldBeUnique, ShouldQueue
         pcntl_alarm(max($this->timeout, 0));
         if ($this->timeout) {
             Cache::put($this->key, 1, $this->timeout);
+        }
+    }
+
+    private static function initializeConnection(self $activity, $connection): void
+    {
+        if ($connection !== null) {
+            $activity->onConnection($connection);
+        } elseif (property_exists($activity, 'connection')) {
+            $activity->onConnection($activity->connection);
+        }
+    }
+
+    private static function initializeQueue(self $activity, $queue): void
+    {
+        if ($queue !== null) {
+            $activity->onQueue($queue);
+        } elseif (property_exists($activity, 'queue')) {
+            $activity->onQueue($activity->queue);
         }
     }
 }

--- a/src/Workflow.php
+++ b/src/Workflow.php
@@ -79,19 +79,12 @@ class Workflow implements ShouldBeEncrypted, ShouldBeUnique, ShouldQueue
 
         $connection = $this->storedWorkflow->effectiveConnection();
 
-        if ($connection !== null) {
-            $this->onConnection($connection);
-        } elseif (property_exists($this, 'connection')) {
-            $this->onConnection($this->connection);
-        }
+        // Give Psalm a base-typed receiver so Queueable is analyzed once per job base class.
+        self::initializeConnection($this, $connection);
 
         $queue = $this->storedWorkflow->effectiveQueue();
 
-        if ($queue !== null) {
-            $this->onQueue($queue);
-        } elseif (property_exists($this, 'queue')) {
-            $this->onQueue($this->queue);
-        }
+        self::initializeQueue($this, $queue);
 
         $this->afterCommit = true;
     }
@@ -311,6 +304,24 @@ class Workflow implements ShouldBeEncrypted, ShouldBeUnique, ShouldQueue
                     $queue
                 );
             }
+        }
+    }
+
+    private static function initializeConnection(self $workflow, $connection): void
+    {
+        if ($connection !== null) {
+            $workflow->onConnection($connection);
+        } elseif (property_exists($workflow, 'connection')) {
+            $workflow->onConnection($workflow->connection);
+        }
+    }
+
+    private static function initializeQueue(self $workflow, $queue): void
+    {
+        if ($queue !== null) {
+            $workflow->onQueue($queue);
+        } elseif (property_exists($workflow, 'queue')) {
+            $workflow->onQueue($workflow->queue);
         }
     }
 

--- a/tests/Unit/ActivityTest.php
+++ b/tests/Unit/ActivityTest.php
@@ -6,6 +6,7 @@ namespace Tests\Unit;
 
 use BadMethodCallException;
 use Exception;
+use Mockery;
 use Tests\Fixtures\TestExceptionActivity;
 use Tests\Fixtures\TestInvalidActivity;
 use Tests\Fixtures\TestNonRetryableExceptionActivity;
@@ -13,12 +14,14 @@ use Tests\Fixtures\TestNullableArgumentsActivity;
 use Tests\Fixtures\TestOtherActivity;
 use Tests\Fixtures\TestWorkflow;
 use Tests\TestCase;
+use Workflow\Activity;
 use Workflow\Exceptions\NonRetryableException;
 use Workflow\Models\StoredWorkflow;
 use Workflow\Serializers\Serializer;
 use Workflow\States\WorkflowCreatedStatus;
 use Workflow\States\WorkflowFailedStatus;
 use Workflow\Webhooks;
+use Workflow\WorkflowOptions;
 use Workflow\WorkflowStub;
 
 final class ActivityTest extends TestCase
@@ -40,7 +43,7 @@ final class ActivityTest extends TestCase
         $this->assertSame($activity->timeout, pcntl_alarm(0));
     }
 
-    public function testActivityUsesWorkflowOptionConnection(): void
+    public function testActivityUsesWorkflowConnectionAndQueueOptions(): void
     {
         $workflow = WorkflowStub::load(WorkflowStub::make(TestWorkflow::class)->id());
         $storedWorkflow = StoredWorkflow::findOrFail($workflow->id());
@@ -48,7 +51,7 @@ final class ActivityTest extends TestCase
             'arguments' => [],
             'options' => [
                 'connection' => 'sync',
-                'queue' => null,
+                'queue' => 'high',
             ],
         ]);
         $storedWorkflow->save();
@@ -56,6 +59,45 @@ final class ActivityTest extends TestCase
         $activity = new TestOtherActivity(0, now()->toDateTimeString(), $storedWorkflow, ['other']);
 
         $this->assertSame('sync', $activity->connection);
+        $this->assertSame('high', $activity->queue);
+    }
+
+    public function testActivityPreservesDefaultConnectionAndQueueWhenWorkflowOptionsAreNull(): void
+    {
+        $storedWorkflow = Mockery::mock(StoredWorkflow::class);
+        $storedWorkflow->shouldReceive('workflowOptions')
+            ->once()
+            ->andReturn(new WorkflowOptions());
+
+        $activity = new class(0, now()->toDateTimeString(), $storedWorkflow) extends Activity {
+            public $connection = 'redis';
+
+            public $queue = 'default';
+
+            public array $routingCalls = [];
+
+            public function onConnection($connection)
+            {
+                $this->routingCalls[] = ['connection', $connection];
+
+                return parent::onConnection($connection);
+            }
+
+            public function onQueue($queue)
+            {
+                $this->routingCalls[] = ['queue', $queue];
+
+                return parent::onQueue($queue);
+            }
+
+            public function execute(): void
+            {
+            }
+        };
+
+        $this->assertSame('redis', $activity->connection);
+        $this->assertSame('default', $activity->queue);
+        $this->assertSame([['connection', 'redis'], ['queue', 'default']], $activity->routingCalls);
     }
 
     public function testInvalidActivity(): void

--- a/tests/Unit/WorkflowTest.php
+++ b/tests/Unit/WorkflowTest.php
@@ -334,20 +334,66 @@ final class WorkflowTest extends TestCase
         $this->assertSame('other', $childWorkflow->output());
     }
 
-    public function testConstructorUsesQueuePropertyWhenEffectiveQueueIsNull(): void
-    {
+    /**
+     * @dataProvider routingProvider
+     */
+    public function testConstructorInitializesRouting(
+        ?string $effectiveConnection,
+        ?string $effectiveQueue,
+        ?string $classConnection,
+        ?string $classQueue,
+        ?string $expectedConnection,
+        ?string $expectedQueue
+    ): void {
         $storedWorkflow = Mockery::mock(StoredWorkflow::class);
         $storedWorkflow->shouldReceive('effectiveConnection')
             ->once()
-            ->andReturn('sync');
+            ->andReturn($effectiveConnection);
         $storedWorkflow->shouldReceive('effectiveQueue')
             ->once()
-            ->andReturn(null);
+            ->andReturn($effectiveQueue);
 
-        $workflow = new Workflow($storedWorkflow);
+        $workflow = new class($storedWorkflow, $classConnection, $classQueue) extends Workflow {
+            public array $routingCalls = [];
 
-        $this->assertSame('sync', $workflow->connection);
-        $this->assertNull($workflow->queue);
+            public function __construct(StoredWorkflow $storedWorkflow, ?string $connection, ?string $queue)
+            {
+                $this->connection = $connection;
+                $this->queue = $queue;
+
+                parent::__construct($storedWorkflow);
+            }
+
+            public function onConnection($connection)
+            {
+                $this->routingCalls[] = ['connection', $connection];
+
+                return parent::onConnection($connection);
+            }
+
+            public function onQueue($queue)
+            {
+                $this->routingCalls[] = ['queue', $queue];
+
+                return parent::onQueue($queue);
+            }
+        };
+
+        $this->assertSame($expectedConnection, $workflow->connection);
+        $this->assertSame($expectedQueue, $workflow->queue);
+        $this->assertSame([
+            ['connection', $expectedConnection],
+            ['queue', $expectedQueue],
+        ], $workflow->routingCalls);
+    }
+
+    public static function routingProvider(): array
+    {
+        return [
+            'effective routing' => ['sync', 'high', null, null, 'sync', 'high'],
+            'mixed routing' => ['sync', null, null, null, 'sync', null],
+            'class defaults' => [null, null, 'redis', 'default', 'redis', 'default'],
+        ];
     }
 
     public function testThrowsWhenExecuteMethodIsMissing(): void


### PR DESCRIPTION
Fixes #399.

## Root cause

`Activity` and `Workflow` initialized Laravel queue routing through `Queueable`'s fluent setters on the subclass-typed `$this`. Psalm specializes the trait's `$this` return type for every job subclass, then repeatedly reports that `Queueable.php` cannot use its cache.

The refactor in #401 does not touch that call path; the compact reproduction below remains at 19 total / 17 analysis-phase `Queueable` reparses on both master and #401.

## Fix

- pass each job through private static helpers with a concrete `Activity` or `Workflow` receiver
- keep the original `effectiveConnection → onConnection → effectiveQueue → onQueue` order
- preserve overridable `onConnection()` / `onQueue()` dispatch, subclass defaults, and Laravel's enum normalization
- cover effective values, mixed null values, subclass defaults, and setter dispatch

## Results

Pinned environment: PHP 8.5.8, Laravel 13.20.0, Psalm 6.16.1. All runs completed with no Psalm errors.

| Compact reproduction | Total `Queueable` reparses | Analysis-phase reparses |
| --- | ---: | ---: |
| master (`d502e26`) | 19 | 17 |
| PR #401 (`8bf64429`) | 19 | 17 |
| this PR | 3 | 1 |

A 120-activity amplification microbenchmark using one PSR-4 file per activity completed in 10.38s on master and 7.37s on this PR. Reparse counts fell from 963 to 3. With Psalm's cache warmed, they remained 962 on master and fell to 2 here.

## Validation

- `composer ecs`
- `composer stan`
- focused Activity and Workflow routing tests
- Laravel 13 runtime probe for overridden setters, lookup order, and enum-backed defaults
- Psalm compact reproduction and 120-activity amplification microbenchmark
- GitHub Actions build and Codecov patch/project checks

<details>
<summary>Copy/paste Psalm reproduction</summary>

```bash
repro_dir="$(mktemp -d)"
trap 'rm -rf "$repro_dir"' EXIT

git clone --quiet https://github.com/durable-workflow/workflow.git "$repro_dir/repo"
git -C "$repro_dir/repo" worktree add --detach "$repro_dir/master" d502e26e91818afcc96164e9962a38d0da453909
git -C "$repro_dir/repo" worktree add --detach "$repro_dir/pr" 02af9b1c6c8bf6571e9cc5187107fde0097b5246
mkdir -p "$repro_dir/bench/src"

cat >"$repro_dir/bench/composer.json" <<'JSON'
{
  "name": "durable-workflow/issue-399-repro",
  "type": "project",
  "require": {
    "php": "^8.3",
    "durable-workflow/workflow": "1.0.78",
    "laravel/framework": "13.20.0",
    "vimeo/psalm": "6.16.1"
  },
  "repositories": [{
    "type": "path",
    "url": "/workflow",
    "options": {
      "symlink": true,
      "versions": {"durable-workflow/workflow": "1.0.78"}
    }
  }]
}
JSON

cat >"$repro_dir/bench/psalm.xml" <<'XML'
<?xml version="1.0"?>
<psalm xmlns="https://getpsalm.org/schema/config"
       cacheDirectory=".psalm-cache"
       errorLevel="1"
       findUnusedCode="false">
  <projectFiles>
    <directory name="src" />
    <ignoreFiles>
      <directory name="vendor" />
      <directory name="/workflow" />
    </ignoreFiles>
  </projectFiles>
</psalm>
XML

cat >"$repro_dir/bench/src/Repro.php" <<'PHP'
<?php

declare(strict_types=1);

namespace Repro;

use Generator;
use Workflow\Activity;
use Workflow\Workflow;

final class SlotPublishWorkflow extends Workflow
{
    public function execute(): Generator
    {
        yield from [];
    }
}

final class PublishSlotActivity extends Activity
{
    public function execute(SlotPublisher $publisher, Slot $slot): void
    {
        $publisher->publish($slot);
    }
}

final class SlotPublisher
{
    public function publish(Slot $slot): void
    {
    }
}

final class Slot
{
}
PHP

docker run --rm -u "$(id -u):$(id -g)" \
  -e COMPOSER_HOME=/tmp/composer \
  -v "$repro_dir/master:/workflow:ro" \
  -v "$repro_dir/bench:/bench" -w /bench \
  composer:2.10.2 composer update --no-interaction --prefer-dist --no-progress

run_psalm () {
  repro_label="$1"
  workflow_source="$2"

  docker run --rm -u "$(id -u):$(id -g)" \
    -v "$workflow_source:/workflow:ro" \
    -v "$repro_dir/bench:/bench" -w /bench \
    composer:2.10.2 \
    vendor/bin/psalm --debug --no-cache --threads=1 src/Repro.php \
    >"$repro_dir/bench/$repro_label.log" 2>&1

  queueable_total="$(grep -c 'Queueable.php because we cannot use cache' "$repro_dir/bench/$repro_label.log")"
  queueable_analysis="$(awk '/Analyzing files/{seen=1; next} seen && /Queueable.php because we cannot use cache/{count++} END{print count+0}' "$repro_dir/bench/$repro_label.log")"
  printf '%s: total=%s analysis=%s\n' "$repro_label" "$queueable_total" "$queueable_analysis"
}

run_psalm master "$repro_dir/master"
run_psalm pr-402 "$repro_dir/pr"
```

Expected output:

```text
master: total=19 analysis=17
pr-402: total=3 analysis=1
```

Both Psalm logs end with `No errors found!`.

</details>
