### PR TITLE
Link organization-wide agent guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,13 @@
+# Repository Agent Guide
+
+Follow the [Durable Workflow organization-wide agent guide](https://github.com/durable-workflow/.github/blob/main/AGENTS.md).
+
+## Quality Cycle
+
+Run these commands before considering a change complete:
+
+1. `composer ecs` - fix code style.
+2. `composer stan` - run static analysis with no errors.
+3. `composer unit` - run the unit suite.
+4. `composer coverage` - maintain the repository's coverage requirement.
+5. `composer feature` - run the feature suite.


### PR DESCRIPTION
Part of durable-workflow/.github#95.

Adds a root `AGENTS.md` pointer to the public organization-wide guide so a human or agent starting from this repository can discover the shared product, issue, security, conformance, and release rules. Existing repository-specific guidance is preserved.

Validation: `git diff --check`.