### PR TITLE
Prepare Workflow 2.0.0 stable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Workflow `2.0.0` promotes the fully qualified release-candidate runtime to
+  the stable 2.0 line without changing its durable execution behavior.
 - Workflow `2.0.0-rc.55` treats the official stable-v1 Y and Base64 serializer
   settings as nonblocking migration diagnostics while v1 runs drain, without
   changing the Avro-only codec used for all new v2 payloads.

--- a/composer.json
+++ b/composer.json
@@ -76,7 +76,7 @@
     },
     "extra": {
         "durable-workflow": {
-            "product-train": "2.0.0-rc.55",
+            "product-train": "2.0.0",
             "laravel-embedded-upgrade-contract": "resources/laravel-embedded-upgrade-contract.json",
             "laravel-dependency-security-policy": "resources/laravel-dependency-security-policy.json"
         },


### PR DESCRIPTION
## Summary

- promote Workflow source identity from `2.0.0-rc.55` to `2.0.0`
- record the stable promotion in the changelog
- leave runtime code and dependency constraints unchanged from the qualified candidate

Stable publication is authorized in durable-workflow/.github#97 after the exact release-critical tuple passed 16/16 experiments.

## Verification

- `composer.json` validates as JSON and declares product train `2.0.0`
- GitHub CI is authoritative for the existing multi-version Laravel matrix