### PR TITLE
Accept stable Workflow source identities

### DIFF
--- a/tests/Unit/V2/PlatformConformanceSuiteTest.php
+++ b/tests/Unit/V2/PlatformConformanceSuiteTest.php
@@ -1031,7 +1031,10 @@ final class PlatformConformanceSuiteTest extends TestCase
         $contracts = $suiteManifest['fixture_catalog']['signal_query_runtime_contract']['required_scenario_contracts'];
 
         $this->assertIsString($workflowSourceRelease);
-        $this->assertMatchesRegularExpression('/^\d+\.\d+\.\d+-rc\.\d+$/', $workflowSourceRelease);
+        $this->assertMatchesRegularExpression(
+            '/^(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)(?:-(?:alpha|beta|rc)\.(?:0|[1-9]\d*))?$/D',
+            $workflowSourceRelease,
+        );
 
         foreach ($sdkCompatibility as $sdk) {
             $this->assertSame('2.0.0-rc.5', $sdk['release_line']);


### PR DESCRIPTION
## Summary

- allow exact stable SemVer in the Workflow source-release contract
- retain alpha, beta, and RC source identities for future prerelease trains
- continue rejecting malformed versions and leading-zero prerelease ordinals

This fixes the single assertion found by the stable branch coverage run after durable-workflow/.github#97 authorized `2.0.0`.

## Verification

- PHP syntax check passed
- exact matcher accepts `2.0.0`, RC, and beta examples
- malformed `2.0.0-rc.01` and `latest` are rejected