### PR TITLE
Preserve portable exception traces in Avro

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Workflow `2.0.1` keeps PHP exception traces Avro-portable when argument
+  capture is enabled, preserving each frame's durable fields while omitting
+  object and resource values that cannot cross the public payload boundary.
 - Workflow `2.0.0` promotes the fully qualified release-candidate runtime to
   the stable 2.0 line without changing its durable execution behavior.
 - Workflow `2.0.0-rc.55` treats the official stable-v1 Y and Base64 serializer

--- a/composer.json
+++ b/composer.json
@@ -76,7 +76,7 @@
     },
     "extra": {
         "durable-workflow": {
-            "product-train": "2.0.0",
+            "product-train": "2.0.1",
             "laravel-embedded-upgrade-contract": "resources/laravel-embedded-upgrade-contract.json",
             "laravel-dependency-security-policy": "resources/laravel-dependency-security-policy.json"
         },

--- a/scripts/ci/validate-regression-corpus.py
+++ b/scripts/ci/validate-regression-corpus.py
@@ -138,6 +138,16 @@ OFFICIAL_BINDING_CONSUMER_SUPPORT = {
     OFFICIAL_BINDING_CONSUMERS[
         (
             "php",
+            "codec",
+            "tests/Fixtures/V2/CodecRegression/*.json",
+            "codec-regression-v1",
+        )
+    ]: (
+        "tests/Unit/Serializers/AvroValueProtocolTest.php",
+    ),
+    OFFICIAL_BINDING_CONSUMERS[
+        (
+            "php",
             "replay",
             "tests/Fixtures/V2/ReplayRegression/*.json",
             "replay-regression-v1",

--- a/src/Serializers/Serializer.php
+++ b/src/Serializers/Serializer.php
@@ -270,11 +270,42 @@ final class Serializer
             'code' => $throwable->getCode(),
             'line' => $throwable->getLine(),
             'file' => $throwable->getFile(),
-            'trace' => collect($throwable->getTrace())
-                ->filter(static fn ($trace) => self::serializable($trace))
-                ->values()
-                ->toArray(),
+            'trace' => self::portableThrowableTrace($throwable),
         ];
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    private static function portableThrowableTrace(Throwable $throwable): array
+    {
+        return collect($throwable->getTrace())
+            ->filter(static fn (mixed $frame): bool => is_array($frame))
+            ->map(static function (array $frame): array {
+                $portable = [];
+
+                foreach ($frame as $key => $value) {
+                    if (is_string($key) && self::isPortableAvroValue($value)) {
+                        $portable[$key] = $value;
+                    }
+                }
+
+                return $portable;
+            })
+            ->filter(static fn (array $frame): bool => $frame !== [])
+            ->values()
+            ->toArray();
+    }
+
+    private static function isPortableAvroValue(mixed $value): bool
+    {
+        try {
+            Avro::serialize($value);
+
+            return true;
+        } catch (Throwable) {
+            return false;
+        }
     }
 
     private static function helper(): ModelIdentifierHelper

--- a/tests/Fixtures/V2/CodecRegression/avro-throwable-trace-object-argument.json
+++ b/tests/Fixtures/V2/CodecRegression/avro-throwable-trace-object-argument.json
@@ -1,0 +1,48 @@
+{
+  "$schema": "https://raw.githubusercontent.com/durable-workflow/.github/main/regression-corpus/evidence-schema.json",
+  "fixture_schema": "durable-workflow.codec-regression/v1",
+  "id": "avro-throwable-trace-object-argument",
+  "protocol": {
+    "codec": "avro",
+    "schema": "durable_workflow.protocol.Value",
+    "version": "1",
+    "fingerprint": "e2a33dff55802237"
+  },
+  "bindings": [
+    "php"
+  ],
+  "value": {
+    "type": "map",
+    "entries": [
+      {
+        "key": "frame_class",
+        "value": {
+          "type": "string",
+          "value": "Tests\\Unit\\Serializers\\AvroValueProtocolTest"
+        }
+      },
+      {
+        "key": "frame_function",
+        "value": {
+          "type": "string",
+          "value": "throwableWithObjectArgumentForCorpus"
+        }
+      },
+      {
+        "key": "object_argument_omitted",
+        "value": {
+          "type": "boolean",
+          "value": true
+        }
+      }
+    ]
+  },
+  "framing": {
+    "encoding": "avro-single-object",
+    "wire_base64": "wwHioz3/VYAiNw4GFmZyYW1lX2NsYXNzClhUZXN0c1xVbml0XFNlcmlhbGl6ZXJzXEF2cm9WYWx1ZVByb3RvY29sVGVzdBxmcmFtZV9mdW5jdGlvbgpIdGhyb3dhYmxlV2l0aE9iamVjdEFyZ3VtZW50Rm9yQ29ycHVzLm9iamVjdF9hcmd1bWVudF9vbWl0dGVkAgEA"
+  },
+  "failure_policy": {
+    "operation": "round_trip",
+    "error": null
+  }
+}

--- a/tests/Unit/Serializers/AvroValueProtocolTest.php
+++ b/tests/Unit/Serializers/AvroValueProtocolTest.php
@@ -278,7 +278,8 @@ final class AvroValueProtocolTest extends TestCase
         self::assertSame('avro', $fixture['protocol']['codec'] ?? null);
         self::assertSame(Avro::valueSchemaFingerprint(), $fixture['protocol']['fingerprint'] ?? null);
 
-        $value = self::taggedValue($fixture['value']);
+        $expected = self::taggedValue($fixture['value']);
+        $value = self::observedCodecValue($fixture, $expected);
         $wire = $fixture['framing']['wire_base64'] ?? null;
         $operation = $fixture['failure_policy']['operation'] ?? null;
         $error = $fixture['failure_policy']['error'] ?? null;
@@ -327,5 +328,62 @@ final class AvroValueProtocolTest extends TestCase
             )),
             default => throw new InvalidArgumentException('Unsupported tagged corpus value.'),
         };
+    }
+
+    /**
+     * @param array<string, mixed> $fixture
+     */
+    private static function observedCodecValue(array $fixture, mixed $expected): mixed
+    {
+        if (($fixture['id'] ?? null) !== 'avro-throwable-trace-object-argument') {
+            return $expected;
+        }
+
+        $previous = ini_get('zend.exception_ignore_args');
+        ini_set('zend.exception_ignore_args', '0');
+
+        try {
+            $argument = new \stdClass();
+            $throwable = self::throwableWithObjectArgumentForCorpus($argument);
+            self::assertSame($argument, $throwable->getTrace()[0]['args'][0]);
+
+            $decoded = Serializer::unserializeWithCodec(
+                'avro',
+                Serializer::serializeWithCodec('avro', $throwable),
+            );
+        } finally {
+            ini_set('zend.exception_ignore_args', (string) $previous);
+        }
+
+        $frame = null;
+        foreach ($decoded['trace'] ?? [] as $candidate) {
+            if (($candidate['function'] ?? null) === 'throwableWithObjectArgumentForCorpus') {
+                $frame = $candidate;
+                break;
+            }
+        }
+
+        self::assertIsArray($frame);
+        self::assertInstanceOf(AvroMapValue::class, $expected);
+        $observed = [
+            'frame_class' => $frame['class'] ?? null,
+            'frame_function' => $frame['function'] ?? null,
+            'object_argument_omitted' => ! array_key_exists('args', $frame),
+        ];
+        self::assertSame(
+            $expected->pairs,
+            array_map(
+                static fn (string $key, mixed $value): array => [$key, $value],
+                array_keys($observed),
+                array_values($observed),
+            ),
+        );
+
+        return $observed;
+    }
+
+    private static function throwableWithObjectArgumentForCorpus(object $argument): \RuntimeException
+    {
+        return new \RuntimeException('codec regression corpus');
     }
 }

--- a/tests/Unit/Serializers/CodecIndependentHelpersTest.php
+++ b/tests/Unit/Serializers/CodecIndependentHelpersTest.php
@@ -113,6 +113,34 @@ final class CodecIndependentHelpersTest extends TestCase
         $this->assertIsArray($decoded['trace']);
     }
 
+    public function testAvroThrowableTraceOmitsOnlyNonPortableFields(): void
+    {
+        $previous = ini_get('zend.exception_ignore_args');
+        ini_set('zend.exception_ignore_args', '0');
+
+        try {
+            $argument = new \stdClass();
+            $throwable = $this->throwableWithObjectArgument($argument);
+            $trace = $throwable->getTrace();
+
+            $this->assertSame($argument, $trace[0]['args'][0]);
+
+            $decoded = Serializer::unserializeWithCodec(
+                'avro',
+                Serializer::serializeWithCodec('avro', $throwable),
+            );
+        } finally {
+            ini_set('zend.exception_ignore_args', (string) $previous);
+        }
+
+        $frame = collect($decoded['trace'])
+            ->firstWhere('function', 'throwableWithObjectArgument');
+
+        $this->assertIsArray($frame);
+        $this->assertSame(self::class, $frame['class']);
+        $this->assertArrayNotHasKey('args', $frame);
+    }
+
     public static function languageNeutralCodecProvider(): array
     {
         $cases = [];
@@ -146,5 +174,10 @@ final class CodecIndependentHelpersTest extends TestCase
             'Y' => [Y::class],
             'Base64' => [Base64::class],
         ];
+    }
+
+    private function throwableWithObjectArgument(object $argument): Exception
+    {
+        return new Exception('trace boom');
     }
 }


### PR DESCRIPTION
## Summary
- preserve portable fields from every PHP exception trace frame
- omit object/resource fields that cannot cross the fixed Avro Value boundary
- cover `zend.exception_ignore_args=0` with an object-valued trace argument

## Verification
- focused regression: 1 test, 4 assertions
- PHPStan on changed source and test
- direct stable-code reproduction before fix, successful Avro round trip after fix
- repository formatter and `git diff --check`