### PR TITLE
Make parallel child replay corpus authentic

### DIFF
--- a/scripts/ci/validate-regression-corpus.py
+++ b/scripts/ci/validate-regression-corpus.py
@@ -157,6 +157,7 @@ OFFICIAL_BINDING_CONSUMER_SUPPORT = {
         "tests/Fixtures/V2/TestConstructorInjectionActivity.php",
         "tests/Fixtures/V2/TestConstructorInjectionWorkflow.php",
         "tests/Fixtures/V2/TestPortableLocalActivityIdentityWorkflow.php",
+        "tests/Fixtures/V2/TestParallelChildReplayWorkflow.php",
         "tests/Fixtures/V2/TestSequentialChildReplayWorkflow.php",
         "tests/Fixtures/V2/TestServiceResponseReplayWorkflow.php",
         "tests/Fixtures/V2/TestSignalResumedParallelWorkflow.php",

--- a/tests/Feature/V2/V2EmbeddedReplayRegressionCorpusTest.php
+++ b/tests/Feature/V2/V2EmbeddedReplayRegressionCorpusTest.php
@@ -65,6 +65,10 @@ final class V2EmbeddedReplayRegressionCorpusTest extends TestCase
             }
 
             if (($fixture['id'] ?? null) === 'parallel-child-group-final-sibling-release') {
+                $this->assertLegacyParallelChildRawHistoryGap($fixture);
+            }
+
+            if (($fixture['id'] ?? null) === 'parallel-child-group-durable-command-sequence') {
                 $this->assertStandaloneParallelChildBarrierFixture($fixture);
             }
 
@@ -164,6 +168,29 @@ final class V2EmbeddedReplayRegressionCorpusTest extends TestCase
     /**
      * @param array<string, mixed> $fixture
      */
+    private function assertLegacyParallelChildRawHistoryGap(array $fixture): void
+    {
+        $scheduledEvents = array_values(array_filter(
+            $fixture['history'],
+            static fn (array $event): bool => ($event['event_type'] ?? null) === 'ChildWorkflowScheduled',
+        ));
+        $completionEvents = array_values(array_filter(
+            $fixture['history'],
+            static fn (array $event): bool => ($event['event_type'] ?? null) === 'ChildRunCompleted',
+        ));
+
+        $this->assertSame([2, 3], array_column($scheduledEvents, 'sequence'));
+        $this->assertSame([3, 4], array_column(array_column($scheduledEvents, 'payload'), 'sequence'));
+        $this->assertSame([3, 3], array_column(
+            array_column($scheduledEvents, 'payload'),
+            'parallel_group_base_sequence',
+        ));
+        $this->assertSame([4, 3], array_column(array_column($completionEvents, 'payload'), 'sequence'));
+    }
+
+    /**
+     * @param array<string, mixed> $fixture
+     */
     private function assertStandaloneParallelChildBarrierFixture(array $fixture): void
     {
         $this->clearWorkflowState();
@@ -188,6 +215,23 @@ final class V2EmbeddedReplayRegressionCorpusTest extends TestCase
         $claim = $bridge->claimStatus($parentTask->id, 'regression-corpus-parent-worker');
         $this->assertTrue($claim['claimed']);
 
+        $initialHistory = $bridge->historyPayload($parentTask->id);
+        $this->assertNotNull($initialHistory);
+
+        $authored = WorkflowFiberRunner::forClass(
+            $workflow['type'],
+            $parentRun->workflow_instance_id,
+            $parentRun->id,
+            $workflow['arguments'],
+            $workflow['payload_codec'],
+            $initialHistory['history_events'],
+        )->step();
+        $this->assertFalse($authored->completed);
+        $this->assertSame(
+            ['start_child_workflow', 'start_child_workflow'],
+            array_column($authored->commands, 'type'),
+        );
+
         $scheduledEvents = array_values(array_filter(
             $fixture['history'],
             static fn (array $event): bool => ($event['event_type'] ?? null) === 'ChildWorkflowScheduled',
@@ -202,41 +246,32 @@ final class V2EmbeddedReplayRegressionCorpusTest extends TestCase
             'parallel_group_index',
             'parallel_group_path',
         ]);
-        $commands = array_map(
-            static function (array $event) use ($parallelKeys, $workflow): array {
-                $payload = $event['payload'];
-                $groupIndex = $payload['parallel_group_index'];
-
-                return [
-                    'type' => 'start_child_workflow',
-                    'workflow_type' => $payload['child_workflow_type'],
-                    'arguments' => Serializer::serializeWithCodec(
-                        $workflow['payload_codec'],
-                        [$workflow['arguments'][$groupIndex]],
-                    ),
-                    'payload_codec' => $workflow['payload_codec'],
-                    ...array_intersect_key($payload, $parallelKeys),
-                ];
-            },
-            $scheduledEvents,
+        $this->assertSame([1, 2], array_column(array_column($scheduledEvents, 'payload'), 'sequence'));
+        $this->assertEquals(
+            array_map(
+                static fn (array $event): array => array_intersect_key($event['payload'], $parallelKeys),
+                $scheduledEvents,
+            ),
+            array_map(
+                static fn (array $command): array => array_intersect_key($command, $parallelKeys),
+                $authored->commands,
+            ),
         );
 
-        $scheduled = $bridge->complete($parentTask->id, $commands);
-        if (! $scheduled['completed'] && $scheduled['reason'] === 'invalid_commands') {
-            foreach ([
-                1 => 'prepared',
-                2 => 'ready',
-            ] as $sequence => $result) {
-                WorkflowHistoryEvent::record($parentRun, HistoryEventType::SideEffectRecorded, [
-                    'sequence' => $sequence,
-                    'result' => Serializer::serializeWithCodec($workflow['payload_codec'], $result),
-                ], $parentTask);
-            }
-
-            $scheduled = $bridge->complete($parentTask->id, $commands);
-        }
+        $scheduled = $bridge->complete($parentTask->id, $authored->commands);
         $this->assertTrue($scheduled['completed'], json_encode($scheduled, JSON_THROW_ON_ERROR));
         $this->assertCount(2, $scheduled['created_task_ids']);
+        $this->assertSame(0, WorkflowHistoryEvent::query()
+            ->where('workflow_run_id', $parentRun->id)
+            ->where('event_type', HistoryEventType::SideEffectRecorded->value)
+            ->count());
+        $this->assertSame([1, 2], WorkflowHistoryEvent::query()
+            ->where('workflow_run_id', $parentRun->id)
+            ->where('event_type', HistoryEventType::ChildWorkflowScheduled->value)
+            ->orderBy('sequence')
+            ->get()
+            ->map(static fn (WorkflowHistoryEvent $event): mixed => $event->payload['sequence'] ?? null)
+            ->all());
 
         $childTasks = WorkflowLink::query()
             ->where('parent_workflow_run_id', $parentRun->id)
@@ -252,7 +287,7 @@ final class V2EmbeddedReplayRegressionCorpusTest extends TestCase
             $fixture['history'],
             static fn (array $event): bool => ($event['event_type'] ?? null) === 'ChildRunCompleted',
         ));
-        $this->assertSame([4, 3], array_column(array_column($completionEvents, 'payload'), 'sequence'));
+        $this->assertSame([2, 1], array_column(array_column($completionEvents, 'payload'), 'sequence'));
 
         $openParentTaskCount = static fn (): int => WorkflowTask::query()
             ->where('workflow_run_id', $parentRun->id)
@@ -303,6 +338,43 @@ final class V2EmbeddedReplayRegressionCorpusTest extends TestCase
             ->where('workflow_run_id', $parentRun->id)
             ->where('event_type', HistoryEventType::ChildRunCompleted->value)
             ->count());
+
+        /** @var WorkflowTask $replacementTask */
+        $replacementTask = WorkflowTask::query()
+            ->where('workflow_run_id', $parentRun->id)
+            ->where('task_type', TaskType::Workflow->value)
+            ->where('status', TaskStatus::Ready->value)
+            ->sole();
+        $replacementClaim = $bridge->claimStatus($replacementTask->id, 'regression-corpus-replacement-worker');
+        $this->assertTrue($replacementClaim['claimed']);
+
+        $replacementHistory = $bridge->historyPayload($replacementTask->id);
+        $this->assertNotNull($replacementHistory);
+        $coldReplay = WorkflowFiberRunner::forClass(
+            $workflow['type'],
+            $parentRun->workflow_instance_id,
+            $parentRun->id,
+            $workflow['arguments'],
+            $workflow['payload_codec'],
+            $replacementHistory['history_events'],
+        )->step();
+
+        $this->assertTrue($coldReplay->completed);
+        $this->assertSame(['complete_workflow'], array_column($coldReplay->commands, 'type'));
+        $this->assertSame([
+            [
+                'child' => 'first',
+            ],
+            [
+                'child' => 'second',
+            ],
+        ], $coldReplay->result['children'] ?? null);
+        $this->assertSame($stub->workflowId(), $coldReplay->result['workflow_id'] ?? null);
+        $this->assertSame($parentRun->id, $coldReplay->result['run_id'] ?? null);
+
+        $finished = $bridge->complete($replacementTask->id, $coldReplay->commands);
+        $this->assertTrue($finished['completed'], json_encode($finished, JSON_THROW_ON_ERROR));
+        $this->assertSame('completed', $finished['run_status']);
     }
 
     /**

--- a/tests/Fixtures/V2/ReplayRegression/parallel-child-group-durable-command-sequence.json
+++ b/tests/Fixtures/V2/ReplayRegression/parallel-child-group-durable-command-sequence.json
@@ -1,0 +1,143 @@
+{
+  "$schema": "https://raw.githubusercontent.com/durable-workflow/.github/main/regression-corpus/evidence-schema.json",
+  "fixture_schema": "durable-workflow.replay-regression/v1",
+  "id": "parallel-child-group-durable-command-sequence",
+  "protocol_version": "1.0",
+  "bindings": [
+    "php"
+  ],
+  "workflow": {
+    "type": "Tests\\Fixtures\\V2\\TestParallelChildReplayWorkflow",
+    "arguments": [
+      "first",
+      "second"
+    ],
+    "payload_codec": "avro"
+  },
+  "history": [
+    {
+      "sequence": 1,
+      "event_type": "WorkflowStarted",
+      "payload": {},
+      "recorded_at": "2026-08-31T09:00:00+00:00"
+    },
+    {
+      "sequence": 2,
+      "event_type": "ChildWorkflowScheduled",
+      "payload": {
+        "sequence": 1,
+        "child_workflow_type": "Tests\\Fixtures\\V2\\TestChildGreetingWorkflow",
+        "parallel_group_id": "parallel-children:1:2",
+        "parallel_group_kind": "child",
+        "parallel_group_base_sequence": 1,
+        "parallel_group_size": 2,
+        "parallel_group_index": 0,
+        "parallel_group_path": [
+          {
+            "parallel_group_id": "parallel-children:1:2",
+            "parallel_group_kind": "child",
+            "parallel_group_base_sequence": 1,
+            "parallel_group_size": 2,
+            "parallel_group_index": 0
+          }
+        ]
+      },
+      "recorded_at": "2026-08-31T09:00:01+00:00"
+    },
+    {
+      "sequence": 3,
+      "event_type": "ChildWorkflowScheduled",
+      "payload": {
+        "sequence": 2,
+        "child_workflow_type": "Tests\\Fixtures\\V2\\TestChildGreetingWorkflow",
+        "parallel_group_id": "parallel-children:1:2",
+        "parallel_group_kind": "child",
+        "parallel_group_base_sequence": 1,
+        "parallel_group_size": 2,
+        "parallel_group_index": 1,
+        "parallel_group_path": [
+          {
+            "parallel_group_id": "parallel-children:1:2",
+            "parallel_group_kind": "child",
+            "parallel_group_base_sequence": 1,
+            "parallel_group_size": 2,
+            "parallel_group_index": 1
+          }
+        ]
+      },
+      "recorded_at": "2026-08-31T09:00:02+00:00"
+    },
+    {
+      "sequence": 4,
+      "event_type": "ChildRunCompleted",
+      "payload": {
+        "sequence": 2,
+        "child_workflow_type": "Tests\\Fixtures\\V2\\TestChildGreetingWorkflow",
+        "child_status": "completed",
+        "output": "wwHioz3/VYAiNw4CCmNoaWxkCgxzZWNvbmQA",
+        "payload_codec": "avro",
+        "parallel_group_id": "parallel-children:1:2",
+        "parallel_group_kind": "child",
+        "parallel_group_base_sequence": 1,
+        "parallel_group_size": 2,
+        "parallel_group_index": 1,
+        "parallel_group_path": [
+          {
+            "parallel_group_id": "parallel-children:1:2",
+            "parallel_group_kind": "child",
+            "parallel_group_base_sequence": 1,
+            "parallel_group_size": 2,
+            "parallel_group_index": 1
+          }
+        ]
+      },
+      "recorded_at": "2026-08-31T09:00:03+00:00"
+    },
+    {
+      "sequence": 5,
+      "event_type": "ChildRunCompleted",
+      "payload": {
+        "sequence": 1,
+        "child_workflow_type": "Tests\\Fixtures\\V2\\TestChildGreetingWorkflow",
+        "child_status": "completed",
+        "output": "wwHioz3/VYAiNw4CCmNoaWxkCgpmaXJzdAA=",
+        "payload_codec": "avro",
+        "parallel_group_id": "parallel-children:1:2",
+        "parallel_group_kind": "child",
+        "parallel_group_base_sequence": 1,
+        "parallel_group_size": 2,
+        "parallel_group_index": 0,
+        "parallel_group_path": [
+          {
+            "parallel_group_id": "parallel-children:1:2",
+            "parallel_group_kind": "child",
+            "parallel_group_base_sequence": 1,
+            "parallel_group_size": 2,
+            "parallel_group_index": 0
+          }
+        ]
+      },
+      "recorded_at": "2026-08-31T09:00:04+00:00"
+    }
+  ],
+  "expected": {
+    "completed": true,
+    "result": {
+      "children": [
+        {
+          "child": "first"
+        },
+        {
+          "child": "second"
+        }
+      ],
+      "workflow_id": "regression-corpus-parallel-child-group-durable-command-sequence",
+      "run_id": "regression-corpus-run-parallel-child-group-durable-command-sequence"
+    },
+    "commands": [
+      {
+        "type": "complete_workflow"
+      }
+    ]
+  }
+}

--- a/tests/Fixtures/V2/TestParallelChildReplayWorkflow.php
+++ b/tests/Fixtures/V2/TestParallelChildReplayWorkflow.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Fixtures\V2;
+
+use function Workflow\V2\all;
+use Workflow\V2\Attributes\Type;
+use function Workflow\V2\child;
+use Workflow\V2\Workflow;
+
+#[Type('test-parallel-child-replay-workflow')]
+final class TestParallelChildReplayWorkflow extends Workflow
+{
+    public function handle(string $firstName, string $secondName): array
+    {
+        $children = all([
+            static fn () => child(TestChildGreetingWorkflow::class, $firstName),
+            static fn () => child(TestChildGreetingWorkflow::class, $secondName),
+        ]);
+
+        return [
+            'children' => $children,
+            'workflow_id' => $this->workflowId(),
+            'run_id' => $this->runId(),
+        ];
+    }
+}

--- a/tests/Unit/V2/ReplayRegressionCorpusTest.php
+++ b/tests/Unit/V2/ReplayRegressionCorpusTest.php
@@ -116,8 +116,12 @@ final class ReplayRegressionCorpusTest extends TestCase
 
         $this->assertStepMatches($fixture['expected'], $step, "{$fixture['id']} final outcome");
 
-        if (($fixture['id'] ?? null) === 'parallel-child-group-final-sibling-release') {
+        if (in_array($fixture['id'] ?? null, [
+            'parallel-child-group-final-sibling-release',
+            'parallel-child-group-durable-command-sequence',
+        ], true)) {
             $this->assertParallelChildReplayPrefix($fixture, $step);
+            $this->assertParallelChildSequenceEra($fixture);
         }
 
         if (($fixture['id'] ?? null) === 'durable-selection-recorded-winner') {
@@ -301,6 +305,47 @@ final class ReplayRegressionCorpusTest extends TestCase
         $this->assertCount(1, $completed->commands);
         $this->assertSame('complete_workflow', $completed->commands[0]['type']);
         $this->assertSame($fixture['expected']['result'], $completed->result);
+    }
+
+    /**
+     * @param array<string, mixed> $fixture
+     */
+    private function assertParallelChildSequenceEra(array $fixture): void
+    {
+        $scheduledEvents = array_values(array_filter(
+            $fixture['history'],
+            static fn (array $event): bool => ($event['event_type'] ?? null) === 'ChildWorkflowScheduled',
+        ));
+        $completionEvents = array_values(array_filter(
+            $fixture['history'],
+            static fn (array $event): bool => ($event['event_type'] ?? null) === 'ChildRunCompleted',
+        ));
+        $expected = match ($fixture['id']) {
+            'parallel-child-group-final-sibling-release' => [
+                'scheduled' => [3, 4],
+                'completed' => [4, 3],
+                'base' => 3,
+            ],
+            'parallel-child-group-durable-command-sequence' => [
+                'scheduled' => [1, 2],
+                'completed' => [2, 1],
+                'base' => 1,
+            ],
+        };
+
+        $this->assertSame([2, 3], array_column($scheduledEvents, 'sequence'));
+        $this->assertSame($expected['scheduled'], array_column(
+            array_column($scheduledEvents, 'payload'),
+            'sequence',
+        ));
+        $this->assertSame([$expected['base'], $expected['base']], array_column(
+            array_column($scheduledEvents, 'payload'),
+            'parallel_group_base_sequence',
+        ));
+        $this->assertSame($expected['completed'], array_column(
+            array_column($completionEvents, 'payload'),
+            'sequence',
+        ));
     }
 
     /**


### PR DESCRIPTION
## Summary

- preserve the immutable legacy raw-history-gap fixture as explicit replay evidence
- add a current durable-command fixture backed by a workflow that actually authors a parallel child group
- require the bridge command batch to succeed on its first attempt without synthetic workflow steps
- prove out-of-order child completion, duplicate delivery rejection, final-sibling release, and cold replay through the persisted bridge history

Progress on #426. The broader v2 coverage target remains open.

## Local verification

- `ReplayRegressionCorpusTest`: 21 tests, 774 assertions
- `V2EmbeddedReplayRegressionCorpusTest`: 1 test, 378 assertions
- regression corpus policy: 61 tests
- full counterfactual corpus validator: pass
- focused ECS: pass
- focused PHPStan: pass