### PR TITLE
Measure v2 coverage across unit and feature suites

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -588,7 +588,7 @@ jobs:
         && needs.route.outputs.qualification == 'full'
       }}
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 18
 
     strategy:
       fail-fast: false
@@ -617,6 +617,12 @@ jobs:
       with:
           fetch-depth: 10
           persist-credentials: false
+
+    - name: Set up PHP coverage driver
+      uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240  # v2
+      with:
+        php-version: '8.3'
+        coverage: pcov
 
     - name: Cache Composer packages
       uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25  # v5
@@ -696,8 +702,9 @@ jobs:
         cp /tmp/mysql-shard-files "build/test-results/mysql-shard-${{ matrix.shard }}-files.txt"
         started_at=$(date +%s)
         set +e
-        timeout --foreground 10m xargs -a /tmp/mysql-shard-files \
+        timeout --foreground 12m xargs -a /tmp/mysql-shard-files \
           vendor/bin/phpunit --testdox --testsuite feature \
+          --coverage-clover "build/test-results/mysql-shard-${{ matrix.shard }}-coverage.xml" \
           --log-junit "build/test-results/mysql-shard-${{ matrix.shard }}.xml"
         status=$?
         elapsed=$(( $(date +%s) - started_at ))
@@ -1007,7 +1014,9 @@ jobs:
         path: vendor/orchestra/testbench-core/laravel/storage/logs/laravel.log
 
   coverage:
-    needs: route
+    needs:
+    - route
+    - feature-mysql
     if: >-
       ${{
         needs.route.outputs.route == 'complete'
@@ -1032,6 +1041,12 @@ jobs:
           persist-credentials: false
           ref: ${{ env.COVERAGE_COMMIT }}
 
+    - name: Set up PHP coverage driver
+      uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240  # v2
+      with:
+        php-version: '8.3'
+        coverage: pcov
+
     - name: Cache Composer packages
       uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25  # v5
       with:
@@ -1042,6 +1057,13 @@ jobs:
 
     - name: Install dependencies
       run: composer install --prefer-dist --no-progress
+
+    - name: Download MySQL feature coverage
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8
+      with:
+        pattern: feature-timing-mysql-*
+        path: build/feature-coverage
+        merge-multiple: true
 
     - name: Create SQLite database on fast temporary storage
       run: |
@@ -1095,10 +1117,16 @@ jobs:
         DB_CONNECTION: sqlite
         DB_DATABASE: ${{ env.COVERAGE_DB_PATH }}
         QUEUE_CONNECTION: sync
-        XDEBUG_MODE: coverage
+        XDEBUG_MODE: off
 
     - name: Enforce the v2 coverage ratchet
-      run: php scripts/ci/check-v2-coverage.php
+      run: >-
+        php scripts/ci/check-v2-coverage.php
+        --clover=coverage.xml
+        --clover=build/feature-coverage/mysql-shard-0-coverage.xml
+        --clover=build/feature-coverage/mysql-shard-1-coverage.xml
+        --clover=build/feature-coverage/mysql-shard-2-coverage.xml
+        --clover=build/feature-coverage/mysql-shard-3-coverage.xml
 
     - name: Upload coverage resource metrics
       if: ${{ always() && github.server_url == 'https://github.com' }}
@@ -1118,10 +1146,10 @@ jobs:
       if: ${{ github.server_url == 'https://github.com' }}
       uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f  # v7
       with:
-        flags: v2-unit
-        files: ./coverage.xml
+        flags: v2
+        files: ./coverage.xml,./build/feature-coverage/mysql-shard-0-coverage.xml,./build/feature-coverage/mysql-shard-1-coverage.xml,./build/feature-coverage/mysql-shard-2-coverage.xml,./build/feature-coverage/mysql-shard-3-coverage.xml
         fail_ci_if_error: true
-        name: v2-unit
+        name: v2
         override_branch: ${{ env.COVERAGE_BRANCH }}
         override_commit: ${{ env.COVERAGE_COMMIT }}
 

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -682,7 +682,7 @@ jobs:
     - name: Create MySQL database
       run: >-
         mysql
-        -e 'SET GLOBAL innodb_flush_log_at_trx_commit=2; SET GLOBAL sync_binlog=0; CREATE DATABASE testbench'
+        -e 'SET GLOBAL innodb_flush_log_at_trx_commit=2; SET GLOBAL sync_binlog=0; SET GLOBAL max_connections=500; CREATE DATABASE testbench'
         -h"$DB_HOST" -uroot -ppassword -P "$DB_PORT"
 
     - name: Run feature test suite (MySQL shard ${{ matrix.shard }})

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
         "test": "phpunit --testdox",
         "coverage": [
             "XDEBUG_MODE=coverage phpunit --testdox --testsuite unit --coverage-clover coverage.xml",
-            "@php scripts/ci/check-v2-coverage.php"
+            "@php scripts/ci/check-v2-coverage.php --contract=resources/v2-unit-coverage-contract.json"
         ],
         "post-autoload-dump": [
             "@clear",

--- a/resources/v2-coverage-contract.json
+++ b/resources/v2-coverage-contract.json
@@ -12,11 +12,11 @@
         }
     },
     "ratchet": {
-        "accepted_baseline_basis_points": 6000,
+        "accepted_baseline_basis_points": 8530,
         "target_basis_points": 10000
     },
     "provenance": {
         "observed_at": "2026-09-01",
-        "evidence": "The branch-bound coverage job unions one unit report with all four MySQL feature-shard reports against the complete production source inventory. The existing 60.00% floor remains in place until the first public combined run establishes the non-decreasing combined baseline."
+        "evidence": "Public full qualification run 33469360974 measured 51,474 of 60,342 executable lines (85.30%) at commit adc71e1b54351274c06ca315a32fb6a8e21135c3 by unioning one unit report with all four MySQL feature-shard reports across the complete production source inventory."
     }
 }

--- a/resources/v2-unit-coverage-contract.json
+++ b/resources/v2-unit-coverage-contract.json
@@ -3,8 +3,7 @@
     "branch": "v2",
     "measurement": {
         "metric": "line",
-        "test_suite": "unit+feature-mysql",
-        "coverage_driver": "pcov",
+        "test_suite": "unit",
         "source": {
             "root": "src",
             "suffix": ".php",
@@ -17,6 +16,6 @@
     },
     "provenance": {
         "observed_at": "2026-09-01",
-        "evidence": "The branch-bound coverage job unions one unit report with all four MySQL feature-shard reports against the complete production source inventory. The existing 60.00% floor remains in place until the first public combined run establishes the non-decreasing combined baseline."
+        "evidence": "The local unit-only command retains the existing 60.00% floor for fast feedback. Public branch qualification uses the combined unit and MySQL feature contract in v2-coverage-contract.json."
     }
 }

--- a/scripts/ci/check-v2-coverage.php
+++ b/scripts/ci/check-v2-coverage.php
@@ -13,11 +13,19 @@ if (isset($arguments['self-test'])) {
     exit(0);
 }
 
-$clover = resolve_path($root, $arguments['clover'] ?? 'coverage.xml');
-$contractPath = resolve_path($root, $arguments['contract'] ?? COVERAGE_CONTRACT);
-$output = resolve_path($root, $arguments['output'] ?? COVERAGE_OUTPUT);
+$cloverArguments = $arguments['clover'] ?? ['coverage.xml'];
+$contractArgument = $arguments['contract'] ?? COVERAGE_CONTRACT;
+$outputArgument = $arguments['output'] ?? COVERAGE_OUTPUT;
+
+if (! is_array($cloverArguments) || ! is_string($contractArgument) || ! is_string($outputArgument)) {
+    fail('Coverage arguments are invalid.');
+}
+
+$clovers = array_map(static fn (string $path): string => resolve_path($root, $path), $cloverArguments);
+$contractPath = resolve_path($root, $contractArgument);
+$output = resolve_path($root, $outputArgument);
 $contract = json_object($contractPath);
-$summary = summarize_coverage($root, $clover, $contract);
+$summary = summarize_coverage($root, $clovers, $contract);
 
 write_json($output, $summary);
 write_step_summary($summary);
@@ -43,7 +51,7 @@ if (! $ratchet['passes']) {
 
 /**
  * @param list<string> $arguments
- * @return array<string, string|true>
+ * @return array<string, string|true|list<string>>
  */
 function parse_arguments(array $arguments): array
 {
@@ -57,13 +65,27 @@ function parse_arguments(array $arguments): array
         }
 
         if (preg_match('/^--(clover|contract|output)=(.+)$/', $argument, $matches) === 1) {
-            $parsed[$matches[1]] = $matches[2];
+            if ($matches[1] === 'clover') {
+                $parsed['clover'] ??= [];
+
+                if (! is_array($parsed['clover'])) {
+                    fail('Coverage Clover arguments are invalid.');
+                }
+
+                $parsed['clover'][] = $matches[2];
+            } else {
+                if (isset($parsed[$matches[1]])) {
+                    fail("Coverage argument [--{$matches[1]}] may be provided only once.");
+                }
+
+                $parsed[$matches[1]] = $matches[2];
+            }
 
             continue;
         }
 
         fail(
-            'Usage: php scripts/ci/check-v2-coverage.php [--clover=path] [--contract=path] [--output=path] [--self-test]'
+            'Usage: php scripts/ci/check-v2-coverage.php [--clover=path ...] [--contract=path] [--output=path] [--self-test]'
         );
     }
 
@@ -74,7 +96,7 @@ function parse_arguments(array $arguments): array
  * @param array<string, mixed> $contract
  * @return array<string, mixed>
  */
-function summarize_coverage(string $root, string $clover, array $contract): array
+function summarize_coverage(string $root, array $clovers, array $contract): array
 {
     $measurement = require_object($contract, 'measurement');
     $source = require_object($measurement, 'source');
@@ -106,7 +128,7 @@ function summarize_coverage(string $root, string $clover, array $contract): arra
 
     $sourceDirectory = resolve_path($root, $sourceRoot);
     $inventory = source_inventory($sourceDirectory, $root, $suffix);
-    $coveredFiles = clover_files($clover, $root);
+    $coveredFiles = clover_files($clovers, $root);
     $missingFiles = array_values(array_diff($inventory, array_keys($coveredFiles)));
     $unexpectedFiles = array_values(array_diff(array_keys($coveredFiles), $inventory));
 
@@ -173,6 +195,7 @@ function summarize_coverage(string $root, string $clover, array $contract): arra
         'measurement' => [
             'metric' => $metric,
             'test_suite' => $testSuite,
+            'report_count' => count($clovers),
             'source' => [
                 'root' => $sourceRoot,
                 'suffix' => $suffix,
@@ -232,9 +255,58 @@ function source_inventory(string $directory, string $root, string $suffix): arra
 }
 
 /**
+ * @param list<string> $clovers
  * @return array<string, array{executable_lines: int, covered_lines: int, uncovered_line_numbers: list<int>}>
  */
-function clover_files(string $clover, string $root): array
+function clover_files(array $clovers, string $root): array
+{
+    if ($clovers === []) {
+        fail('At least one Clover report is required.');
+    }
+
+    $lineCounts = [];
+
+    foreach ($clovers as $clover) {
+        foreach (clover_line_counts($clover, $root) as $path => $lines) {
+            $lineCounts[$path] ??= [];
+
+            foreach ($lines as $number => $count) {
+                $lineCounts[$path][$number] = max($lineCounts[$path][$number] ?? 0, $count);
+            }
+        }
+    }
+
+    $files = [];
+
+    foreach ($lineCounts as $path => $lines) {
+        ksort($lines, SORT_NUMERIC);
+        $uncovered = [];
+        $covered = 0;
+
+        foreach ($lines as $number => $count) {
+            if ($count > 0) {
+                $covered++;
+            } else {
+                $uncovered[] = $number;
+            }
+        }
+
+        $files[$path] = [
+            'executable_lines' => count($lines),
+            'covered_lines' => $covered,
+            'uncovered_line_numbers' => $uncovered,
+        ];
+    }
+
+    ksort($files, SORT_STRING);
+
+    return $files;
+}
+
+/**
+ * @return array<string, array<int, int>>
+ */
+function clover_line_counts(string $clover, string $root): array
 {
     if (! is_file($clover)) {
         fail("Clover report [{$clover}] does not exist.");
@@ -261,9 +333,7 @@ function clover_files(string $clover, string $root): array
         }
 
         $path = normalize_clover_path($file->getAttribute('name'), $root);
-        $executable = 0;
-        $covered = 0;
-        $uncovered = [];
+        $lines = [];
 
         foreach ($file->getElementsByTagName('line') as $line) {
             if (! $line instanceof DOMElement || $line->getAttribute('type') !== 'stmt') {
@@ -277,23 +347,19 @@ function clover_files(string $clover, string $root): array
                 fail("Clover report has invalid line metrics for [{$path}].");
             }
 
-            $executable++;
-            if ($count > 0) {
-                $covered++;
-            } else {
-                $uncovered[] = $number;
+            if (isset($lines[$number])) {
+                fail("Clover report contains duplicate executable line [{$path}:{$number}].");
             }
+
+            $lines[$number] = $count;
         }
 
         if (isset($files[$path])) {
             fail("Clover report contains duplicate file [{$path}].");
         }
 
-        $files[$path] = [
-            'executable_lines' => $executable,
-            'covered_lines' => $covered,
-            'uncovered_line_numbers' => $uncovered,
-        ];
+        ksort($lines, SORT_NUMERIC);
+        $files[$path] = $lines;
     }
 
     ksort($files, SORT_STRING);
@@ -485,6 +551,11 @@ function self_test(string $root): void
         '<?xml version="1.0"?><coverage><project><file name="%s"><line num="2" type="stmt" count="1"/><line num="3" type="stmt" count="0"/></file></project></coverage>',
         htmlspecialchars($source . '/Example.php', ENT_XML1),
     ));
+    $featureClover = $fixture . '/feature-coverage.xml';
+    file_put_contents($featureClover, sprintf(
+        '<?xml version="1.0"?><coverage><project><file name="%s"><line num="2" type="stmt" count="0"/><line num="3" type="stmt" count="1"/></file></project></coverage>',
+        htmlspecialchars($source . '/Example.php', ENT_XML1),
+    ));
 
     $contract = [
         'schema_version' => 1,
@@ -505,7 +576,7 @@ function self_test(string $root): void
     ];
 
     try {
-        $summary = summarize_coverage($fixture, $clover, $contract);
+        $summary = summarize_coverage($fixture, [$clover], $contract);
         assert_self_test($summary['totals']['line_coverage_basis_points'] === 5000, 'calculates line coverage');
         assert_self_test($summary['ratchet']['passes'] === true, 'accepts coverage at the baseline');
         assert_self_test($summary['components'][0]['name'] === 'v2/support', 'groups uncovered paths by component');
@@ -513,14 +584,17 @@ function self_test(string $root): void
             $summary['uncovered_paths'][0]['uncovered_line_numbers'] === [3],
             'reports uncovered executable lines',
         );
+        $combined = summarize_coverage($fixture, [$clover, $featureClover], $contract);
+        assert_self_test($combined['totals']['line_coverage_basis_points'] === 10_000, 'unions line coverage reports');
+        assert_self_test($combined['measurement']['report_count'] === 2, 'reports merged coverage provenance');
 
         $contract['ratchet']['accepted_baseline_basis_points'] = 5001;
-        $summary = summarize_coverage($fixture, $clover, $contract);
+        $summary = summarize_coverage($fixture, [$clover], $contract);
         assert_self_test($summary['ratchet']['passes'] === false, 'rejects a coverage regression');
 
         file_put_contents($fixture . '/src/V2/Support/Missing.php', "<?php\nreturn false;\n");
         try {
-            summarize_coverage($fixture, $clover, $contract);
+            summarize_coverage($fixture, [$clover], $contract);
             fail('Coverage self-test did not reject an omitted production source file.');
         } catch (RuntimeException $exception) {
             assert_self_test(

--- a/scripts/ci/verify-feature-shards.php
+++ b/scripts/ci/verify-feature-shards.php
@@ -99,6 +99,11 @@ function verify_workflow_job(string $workflow, string $job, string $profile): vo
         'weight profile' => "--weight-profile={$profile}",
     ];
 
+    if ($profile === 'mysql') {
+        $requirements['PCOV coverage driver'] = 'coverage: pcov';
+        $requirements['per-shard Clover report'] = '--coverage-clover "build/test-results/mysql-shard-${{ matrix.shard }}-coverage.xml"';
+    }
+
     foreach ($requirements as $description => $needle) {
         if (! str_contains($jobDefinition, $needle)) {
             fail("Build workflow job [{$job}] is missing {$description} [{$needle}].");
@@ -128,16 +133,16 @@ function verify_gate_wiring(string $workflow, string $publicBoundaryWorkflow): v
             "needs.route.outputs.route == 'complete'",
             "needs.route.outputs.qualification == 'full'",
         ],
-        'coverage' => [
-            "needs.route.outputs.route == 'complete'",
-            "needs.route.outputs.qualification == 'full'",
-        ],
+        'coverage' => ["needs.route.outputs.route == 'complete'", "needs.route.outputs.qualification == 'full'"],
     ];
 
     foreach ($routes as $job => $conditions) {
         $definition = workflow_job_definition($workflow, $job);
 
-        if (! str_contains($definition, 'needs: route')) {
+        if (
+            ! str_contains($definition, 'needs: route')
+            && ! str_contains($definition, "needs:\n    - route\n")
+        ) {
             fail("Build workflow job [{$job}] does not depend on route classification.");
         }
 
@@ -153,6 +158,20 @@ function verify_gate_wiring(string $workflow, string $publicBoundaryWorkflow): v
     foreach (array_keys($routes) as $job) {
         if (! str_contains($build, "    - {$job}\n")) {
             fail("Final build gate does not wait for [{$job}].");
+        }
+    }
+
+    $coverage = workflow_job_definition($workflow, 'coverage');
+    foreach (
+        [
+            'feature-shard dependency' => "    - feature-mysql\n",
+            'feature report download' => 'pattern: feature-timing-mysql-*',
+            'first feature report merge input' => '--clover=build/feature-coverage/mysql-shard-0-coverage.xml',
+            'last feature report merge input' => '--clover=build/feature-coverage/mysql-shard-3-coverage.xml',
+        ] as $description => $needle
+    ) {
+        if (! str_contains($coverage, $needle)) {
+            fail("Coverage job is missing {$description} [{$needle}].");
         }
     }
 


### PR DESCRIPTION
## Summary

- collect PCOV Clover reports from the four existing MySQL feature shards
- union those reports with unit coverage against the complete v2 production source inventory
- upload the same five reports to Codecov under one branch-specific `v2` flag
- retain a separate unit-only contract for the fast local `composer coverage` command
- keep feature execution bounded while allowing for coverage overhead

## Result

Full public qualification [33469360974](https://github.com/durable-workflow/workflow/actions/runs/33469360974) passed across all MySQL, PostgreSQL, MariaDB, upgrade, quality, replay, coverage, and Codecov jobs.

The combined PCOV measurement covers **51,474 of 60,342 executable lines (85.30%)** across **522 production files**. The branch ratchet now rejects any result below that exact baseline; the target remains 100%.

## Validation

- coverage merger self-test
- four-shard assignment and workflow-wiring verification
- all four MySQL feature shards under PCOV
- all four PostgreSQL feature shards
- MariaDB compatibility selection
- Laravel 9 through 13 embedded upgrades
- regression corpus
- Composer validation
- PHPStan and ECS
- build-classification contract: 18/18
- workflow YAML parse
- public-boundary scan
- Codecov upload

Advances #426. The issue remains open for the broader 100% v2 coverage target.