### PR TITLE
Update Laravel upgrade CI contract

### DIFF
--- a/tests/Unit/V2/LaravelEmbeddedUpgradeContractTest.php
+++ b/tests/Unit/V2/LaravelEmbeddedUpgradeContractTest.php
@@ -74,10 +74,10 @@ final class LaravelEmbeddedUpgradeContractTest extends TestCase
         $this->assertSame($expectedPublishedMatrix, $publishedMatrix);
         $this->assertSame(
             '${{ steps.laravel-matrix.outputs.matrix }}',
-            $sourceWorkflow['jobs']['route']['outputs']['laravel_source_matrix'],
+            $sourceWorkflow['jobs']['preflight']['outputs']['laravel_source_matrix'],
         );
         $this->assertSame(
-            '${{ fromJSON(needs.route.outputs.laravel_source_matrix) }}',
+            '${{ fromJSON(needs.preflight.outputs.laravel_source_matrix) }}',
             $sourceWorkflow['jobs']['laravel-embedded-upgrade-source']['strategy']['matrix'],
         );
         $this->assertSame(


### PR DESCRIPTION
## Summary

Update the Laravel embedded upgrade contract test to follow the renamed `preflight` job in the source workflow.

## Validation

- focused PHPUnit: 3 tests, 27 assertions
- `git diff --check`

Follow-up to #445.