### PR TITLE
Fix stable Workflow release identity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+## 2.0.2 - 2026-09-01
+
+- Workflow `2.0.2` reports its stable package identity through the platform
+  conformance API, allowing published-package verification after the 2.0 launch.
+
 ## 2.0.1 - 2026-09-01
 
 - Workflow `2.0.1` keeps PHP exception traces Avro-portable when argument

--- a/composer.json
+++ b/composer.json
@@ -76,7 +76,7 @@
     },
     "extra": {
         "durable-workflow": {
-            "product-train": "2.0.1",
+            "product-train": "2.0.2",
             "laravel-embedded-upgrade-contract": "resources/laravel-embedded-upgrade-contract.json",
             "laravel-dependency-security-policy": "resources/laravel-dependency-security-policy.json"
         },

--- a/src/V2/Support/PlatformConformanceSuite.php
+++ b/src/V2/Support/PlatformConformanceSuite.php
@@ -147,8 +147,8 @@ final class PlatformConformanceSuite
         }
 
         $release = is_array($composer) ? ($composer['extra']['durable-workflow']['product-train'] ?? null) : null;
-        if (! is_string($release) || preg_match('/\A2\.0\.0-rc\.[1-9][0-9]*\z/D', $release) !== 1) {
-            throw new RuntimeException('Workflow package metadata must declare one exact 2.0 release candidate.');
+        if (! is_string($release) || preg_match('/\A2\.(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)\z/D', $release) !== 1) {
+            throw new RuntimeException('Workflow package metadata must declare one exact stable 2.x release.');
         }
 
         return $release;

--- a/tests/Unit/V2/PlatformConformanceSuiteTest.php
+++ b/tests/Unit/V2/PlatformConformanceSuiteTest.php
@@ -1031,10 +1031,8 @@ final class PlatformConformanceSuiteTest extends TestCase
         $contracts = $suiteManifest['fixture_catalog']['signal_query_runtime_contract']['required_scenario_contracts'];
 
         $this->assertIsString($workflowSourceRelease);
-        $this->assertMatchesRegularExpression(
-            '/^(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)(?:-(?:alpha|beta|rc)\.(?:0|[1-9]\d*))?$/D',
-            $workflowSourceRelease,
-        );
+        $this->assertMatchesRegularExpression('/^2\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)$/D', $workflowSourceRelease);
+        $this->assertSame($workflowSourceRelease, PlatformConformanceSuite::workflowSourceRelease());
 
         foreach ($sdkCompatibility as $sdk) {
             $this->assertSame('2.0.0-rc.5', $sdk['release_line']);


### PR DESCRIPTION
## Summary

- accept only exact stable `2.x.y` product-train identities after the 2.0 launch
- prepare the corrective `2.0.2` package metadata and changelog
- exercise the public package identity accessor in the platform conformance test

## Why

Published-package verification for `2.0.1` installed successfully, then failed because `PlatformConformanceSuite::workflowSourceRelease()` still required an RC-only version. The retained `2.0.0-rc.42` artifact provenance remains unchanged; this patch fixes only the current package identity.

## Verification

- `PlatformConformanceSuiteTest`: 20 tests, 571 assertions
- focused package identity test: 1 test, 42 assertions
- ECS on changed PHP files
- public-boundary scan
- `git diff --check`