### PR TITLE
Prepare Workflow stable branch for main

### DIFF
--- a/.github/workflows/dependency-security.yml
+++ b/.github/workflows/dependency-security.yml
@@ -2,7 +2,7 @@ name: dependency-security
 
 on:
   push:
-    branches: [v2]
+    branches: [v2, main]
     paths:
       - .github/dependabot.yml
       - .github/workflows/dependency-security.yml
@@ -11,7 +11,7 @@ on:
       - resources/laravel-embedded-upgrade-contract.json
       - scripts/ci/check-laravel-dependency-security.php
   pull_request:
-    branches: [v2]
+    branches: [v2, main]
     paths:
       - .github/dependabot.yml
       - .github/workflows/dependency-security.yml

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -2,9 +2,9 @@ name: build
 
 on:
   push:
-    branches: [v2]
+    branches: [v2, main]
   pull_request:
-    branches: [v2]
+    branches: [v2, main]
   workflow_dispatch:
 
 permissions:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,10 +9,10 @@ applicable.
 ## Local setup
 
 The package supports the PHP versions declared in `composer.json`. Clone the
-`v2` branch and install its development dependencies:
+`main` branch and install its development dependencies:
 
 ```bash
-git clone --branch v2 https://github.com/durable-workflow/workflow.git
+git clone --branch main https://github.com/durable-workflow/workflow.git
 cd workflow
 composer install
 composer build
@@ -65,12 +65,12 @@ and in every applicable official binding.
 
 Fixtures preserve protocol version, value and type, framing, and stable failure
 policy. Existing evidence is append-only. Validate new evidence against the
-pull request's target branch; `origin/v2` is the usual base for this repository,
+pull request's target branch; `origin/main` is the usual base for this repository,
 but set `base_ref` to another target when appropriate:
 
 ```bash
-git fetch origin v2
-base_ref=origin/v2
+git fetch origin main
+base_ref=origin/main
 python scripts/ci/validate-regression-corpus.py --base-ref "$base_ref"
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # Durable Workflow for Laravel
 
 <p align="center">
-  <a href="https://github.com/durable-workflow/workflow/actions/workflows/php.yml?query=branch%3Av2"><img src="https://github.com/durable-workflow/workflow/actions/workflows/php.yml/badge.svg?branch=v2" alt="Build status"></a>
-  <a href="https://codecov.io/gh/durable-workflow/workflow/branch/v2"><img src="https://codecov.io/gh/durable-workflow/workflow/branch/v2/graph/badge.svg" alt="Code coverage"></a>
+  <a href="https://github.com/durable-workflow/workflow/actions/workflows/php.yml?query=branch%3Amain"><img src="https://github.com/durable-workflow/workflow/actions/workflows/php.yml/badge.svg?branch=main" alt="Build status"></a>
+  <a href="https://codecov.io/gh/durable-workflow/workflow/branch/main"><img src="https://codecov.io/gh/durable-workflow/workflow/branch/main/graph/badge.svg" alt="Code coverage"></a>
   <a href="https://packagist.org/packages/durable-workflow/workflow"><img src="https://img.shields.io/packagist/v/durable-workflow/workflow" alt="Latest Packagist version"></a>
   <a href="https://packagist.org/packages/durable-workflow/workflow/stats"><img src="https://img.shields.io/packagist/dt/durable-workflow/workflow" alt="Packagist downloads"></a>
-  <a href="https://github.com/durable-workflow/workflow/blob/v2/LICENSE"><img src="https://img.shields.io/packagist/l/durable-workflow/workflow" alt="MIT license"></a>
+  <a href="https://github.com/durable-workflow/workflow/blob/main/LICENSE"><img src="https://img.shields.io/packagist/l/durable-workflow/workflow" alt="MIT license"></a>
 </p>
 
 Durable Workflow is the embedded Laravel runtime for durable execution. Write

--- a/docs/architecture/testing-strategy.md
+++ b/docs/architecture/testing-strategy.md
@@ -341,7 +341,7 @@ following layers; the table is the inventory of where to look.
 | Workflow package fixtures and feature tests | `durable-workflow/workflow` `tests/` | Author-facing runtime, replay, codec, command, and projection behavior. |
 | Workflow package unit and contract suites | `durable-workflow/workflow` `tests/Unit/V2/` | Documentation pins, surface stability, and durable-row contracts. |
 | Server feature and unit suites | `durable-workflow/server` server tests | HTTP API, worker protocol, control-plane, and operator audit behavior over the wire. |
-| Waterline V2 dedicated suites | `durable-workflow/waterline` v2 tests | Projection-adapter correctness for run summaries, timelines, lineage, failures, commands, waits, timers, and metadata. |
+| Waterline V2 dedicated suites | `durable-workflow/waterline` main-branch tests | Projection-adapter correctness for run summaries, timelines, lineage, failures, commands, waits, timers, and metadata. |
 | Platform conformance fixtures | `docs/architecture/platform-conformance-suite.md` | Cross-repo proof that package, server, CLI, Waterline, SDKs, and managed cloud honor the same buckets. |
 | Replay-debug bundles | `WorkflowReplayer`, `BundleIntegrityVerifier`, replay-diff tooling | Frozen replay proofs that may be carried into other SDKs without rewriting suites. |
 

--- a/resources/sdk-neutrality-contract.json
+++ b/resources/sdk-neutrality-contract.json
@@ -1,7 +1,7 @@
 {
   "schema": "durable-workflow.v2.sdk-neutrality.contract",
   "version": 4,
-  "authority_doc": "https://github.com/durable-workflow/workflow/blob/v2/docs/architecture/sdk-neutrality.md",
+  "authority_doc": "https://github.com/durable-workflow/workflow/blob/main/docs/architecture/sdk-neutrality.md",
   "authority_url": "https://durable-workflow.github.io/sdk-neutrality-contract.json",
   "surface_stability_authority": "durable-workflow.v2.surface-stability.contract",
   "protocol_specs_authority": "durable-workflow.v2.platform-protocol-specs.catalog",

--- a/src/V2/Support/SdkNeutralityContract.php
+++ b/src/V2/Support/SdkNeutralityContract.php
@@ -46,7 +46,7 @@ final class SdkNeutralityContract
 
     public const MIRROR_SHA256 = 'fdd34e4409549cf97325f650bf22f2d7f12a40246eb2949da1f547472ebc5a53';
 
-    public const AUTHORITY_DOC = 'https://github.com/durable-workflow/workflow/blob/v2/docs/architecture/sdk-neutrality.md';
+    public const AUTHORITY_DOC = 'https://github.com/durable-workflow/workflow/blob/main/docs/architecture/sdk-neutrality.md';
 
     public const PUBLIC_CONTRACT_URL = 'https://durable-workflow.github.io/sdk-neutrality-contract.json';
 

--- a/src/V2/Support/ServiceExecutionContract.php
+++ b/src/V2/Support/ServiceExecutionContract.php
@@ -36,7 +36,7 @@ final class ServiceExecutionContract
 
     public const VERSION = 1;
 
-    public const AUTHORITY_DOCUMENT = 'https://github.com/durable-workflow/workflow/blob/v2/docs/architecture/workflow-service-calls-architecture.md';
+    public const AUTHORITY_DOCUMENT = 'https://github.com/durable-workflow/workflow/blob/main/docs/architecture/workflow-service-calls-architecture.md';
 
     public const ADDRESS_FIELDS = ['endpoint_name', 'service_name', 'operation_name'];
 

--- a/tests/Unit/V2/ReadmeBranchDestinationsTest.php
+++ b/tests/Unit/V2/ReadmeBranchDestinationsTest.php
@@ -13,7 +13,7 @@ final class ReadmeBranchDestinationsTest extends TestCase
 {
     private const REPOSITORY_PATH = '/durable-workflow/workflow';
 
-    public function testActionsBadgeAndDestinationAreScopedToV2(): void
+    public function testActionsBadgeAndDestinationAreScopedToMain(): void
     {
         [$destination, $image] = $this->badgeUrls(
             'github.com',
@@ -22,24 +22,24 @@ final class ReadmeBranchDestinationsTest extends TestCase
 
         $this->assertUrl($destination, 'github.com', self::REPOSITORY_PATH . '/actions/workflows/php.yml');
         $this->assertSame([
-            'query' => 'branch:v2',
+            'query' => 'branch:main',
         ], $this->queryParameters($destination));
 
         $this->assertUrl($image, 'github.com', self::REPOSITORY_PATH . '/actions/workflows/php.yml/badge.svg');
         $this->assertSame([
-            'branch' => 'v2',
+            'branch' => 'main',
         ], $this->queryParameters($image));
     }
 
-    public function testCodecovBadgeAndDestinationAreScopedToV2(): void
+    public function testCodecovBadgeAndDestinationAreScopedToMain(): void
     {
         [$destination, $image] = $this->badgeUrls(
             'codecov.io',
-            '/gh' . self::REPOSITORY_PATH . '/branch/v2/graph/badge.svg',
+            '/gh' . self::REPOSITORY_PATH . '/branch/main/graph/badge.svg',
         );
 
-        $this->assertUrl($destination, 'codecov.io', '/gh' . self::REPOSITORY_PATH . '/branch/v2');
-        $this->assertUrl($image, 'codecov.io', '/gh' . self::REPOSITORY_PATH . '/branch/v2/graph/badge.svg');
+        $this->assertUrl($destination, 'codecov.io', '/gh' . self::REPOSITORY_PATH . '/branch/main');
+        $this->assertUrl($image, 'codecov.io', '/gh' . self::REPOSITORY_PATH . '/branch/main/graph/badge.svg');
     }
 
     public function testRepositoryLinksDoNotTargetMaster(): void

--- a/tests/Unit/V2/SdkNeutralityContractTest.php
+++ b/tests/Unit/V2/SdkNeutralityContractTest.php
@@ -44,7 +44,7 @@ final class SdkNeutralityContractTest extends TestCase
         $this->assertSame('durable-workflow.v2.sdk-neutrality.contract', $manifest['schema']);
         $this->assertSame(4, $manifest['version']);
         $this->assertSame(
-            'https://github.com/durable-workflow/workflow/blob/v2/docs/architecture/sdk-neutrality.md',
+            'https://github.com/durable-workflow/workflow/blob/main/docs/architecture/sdk-neutrality.md',
             $manifest['authority_doc'],
         );
         $this->assertSame(

--- a/tests/Unit/V2/ServiceExecutionContractTest.php
+++ b/tests/Unit/V2/ServiceExecutionContractTest.php
@@ -29,7 +29,7 @@ final class ServiceExecutionContractTest extends TestCase
         $this->assertSame('service_execution_contract', $manifest['cluster_info_key']);
         $this->assertSame('service_execution', $manifest['capability_flag']);
         $this->assertSame(
-            'https://github.com/durable-workflow/workflow/blob/v2/docs/architecture/workflow-service-calls-architecture.md',
+            'https://github.com/durable-workflow/workflow/blob/main/docs/architecture/workflow-service-calls-architecture.md',
             $manifest['authority_document'],
         );
     }


### PR DESCRIPTION
Part of #447.

Updates current-line workflows, badges, contribution commands, and repository links for the upcoming `v2` to `main` GitHub branch rename. Triggers temporarily accept both names so the transition merge and the renamed branch can both run checks; the old trigger is removed after the rename.

Validation:
- workflow YAML parse
- `python3 scripts/ci/test-build-routing.py` (10 tests)
- `scripts/check-public-boundary.sh`
- `git diff --check`