### PR TITLE
Align SDK neutrality contract digest

### DIFF
--- a/src/V2/Support/SdkNeutralityContract.php
+++ b/src/V2/Support/SdkNeutralityContract.php
@@ -44,7 +44,7 @@ final class SdkNeutralityContract
 
     public const PACKAGE_CONTRACT_PATH = 'resources/sdk-neutrality-contract.json';
 
-    public const MIRROR_SHA256 = 'fdd34e4409549cf97325f650bf22f2d7f12a40246eb2949da1f547472ebc5a53';
+    public const MIRROR_SHA256 = 'a8397b32297b7817af267b4a24ede10d608fdaad22981e28b20120710f41bbaf';
 
     public const AUTHORITY_DOC = 'https://github.com/durable-workflow/workflow/blob/main/docs/architecture/sdk-neutrality.md';
 


### PR DESCRIPTION
The branch migration updated the packaged SDK-neutrality authority URL but left its integrity constant at the previous file digest. This updates the pinned SHA-256 so the packaged authority can load during the full coverage suite.

Focused verification: `SdkNeutralityContractTest` passes 14 tests / 219 assertions.

Part of #447.