### PR TITLE
Finish Workflow 1.x branch migration

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -3,7 +3,7 @@ name: "Copilot Setup Steps"
 on:
   workflow_dispatch:
   push:
-    branches: [ master, '1.x' ]
+    branches: ['1.x']
     paths:
       - .github/workflows/copilot-setup-steps.yml
   pull_request:

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -2,9 +2,9 @@ name: build
 
 on:
   push:
-    branches: [ master, '1.x' ]
+    branches: ['1.x']
   pull_request:
-    branches: [ master, '1.x' ]
+    branches: ['1.x']
     paths-ignore:
       - README.md
 

--- a/tests/Unit/CiWorkflowPolicyTest.php
+++ b/tests/Unit/CiWorkflowPolicyTest.php
@@ -19,7 +19,7 @@ final class CiWorkflowPolicyTest extends TestCase
 
         self::assertIsString($events);
         self::assertMatchesRegularExpression(
-            "/^  workflow_dispatch:\\R  push:\\R    branches: \\[ master, '1\\.x' \\]\\R    paths:\\R" .
+            "/^  workflow_dispatch:\\R  push:\\R    branches: \\['1\\.x'\\]\\R    paths:\\R" .
             '      - \.github\/workflows\/copilot-setup-steps\.yml$/m',
             $events
         );
@@ -119,14 +119,14 @@ final class CiWorkflowPolicyTest extends TestCase
         $events = strstr(self::workflow(), "\njobs:", true);
 
         self::assertIsString($events);
-        self::assertMatchesRegularExpression("/^  push:\\R    branches: \\[ master, '1\\.x' \\]$/m", $events);
+        self::assertMatchesRegularExpression("/^  push:\\R    branches: \\['1\\.x'\\]$/m", $events);
 
         $push = strstr($events, '  pull_request:', true);
 
         self::assertIsString($push);
         self::assertStringNotContainsString('paths-ignore:', $push);
         self::assertMatchesRegularExpression(
-            "/^  pull_request:\\R    branches: \\[ master, '1\\.x' \\]\\R    paths-ignore:\\R      - README\\.md\\R\\z/m",
+            "/^  pull_request:\\R    branches: \\['1\\.x'\\]\\R    paths-ignore:\\R      - README\\.md\\R\\z/m",
             $events
         );
     }


### PR DESCRIPTION
Removes the temporary `master` compatibility trigger now that the legacy maintenance branch has been renamed to `1.x`. The branch tip, package history, and release tags remain unchanged.

Part of #447.