### PR TITLE
Finish Workflow main branch migration

### DIFF
--- a/.github/workflows/dependency-security.yml
+++ b/.github/workflows/dependency-security.yml
@@ -2,7 +2,7 @@ name: dependency-security
 
 on:
   push:
-    branches: [v2, main]
+    branches: [main]
     paths:
       - .github/dependabot.yml
       - .github/workflows/dependency-security.yml
@@ -11,7 +11,7 @@ on:
       - resources/laravel-embedded-upgrade-contract.json
       - scripts/ci/check-laravel-dependency-security.php
   pull_request:
-    branches: [v2, main]
+    branches: [main]
     paths:
       - .github/dependabot.yml
       - .github/workflows/dependency-security.yml

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -2,9 +2,9 @@ name: build
 
 on:
   push:
-    branches: [v2, main]
+    branches: [main]
   pull_request:
-    branches: [v2, main]
+    branches: [main]
   workflow_dispatch:
 
 permissions:

--- a/composer.json
+++ b/composer.json
@@ -75,6 +75,9 @@
         "durable-workflow/sdk": "Framework-neutral client and remote-worker SDK for the standalone Durable Workflow server."
     },
     "extra": {
+        "branch-alias": {
+            "dev-main": "2.0.x-dev"
+        },
         "durable-workflow": {
             "product-train": "2.0.2",
             "laravel-embedded-upgrade-contract": "resources/laravel-embedded-upgrade-contract.json",


### PR DESCRIPTION
Removes the temporary `v2` compatibility triggers now that `main` is the stable product branch. The required `build` check, package history, and release tags remain unchanged.

Part of #447.