### PR TITLE
Complete durable workflow query contract coverage

### DIFF
--- a/resources/v2-coverage-contract.json
+++ b/resources/v2-coverage-contract.json
@@ -1,6 +1,6 @@
 {
     "schema_version": 1,
-    "branch": "v2",
+    "branch": "main",
     "measurement": {
         "metric": "line",
         "test_suite": "unit+feature-mysql",
@@ -12,11 +12,11 @@
         }
     },
     "ratchet": {
-        "accepted_baseline_basis_points": 8530,
+        "accepted_baseline_basis_points": 8551,
         "target_basis_points": 10000
     },
     "provenance": {
         "observed_at": "2026-09-01",
-        "evidence": "Public full qualification run 33469360974 measured 51,474 of 60,342 executable lines (85.30%) at commit adc71e1b54351274c06ca315a32fb6a8e21135c3 by unioning one unit report with all four MySQL feature-shard reports across the complete production source inventory."
+        "evidence": "Public full qualification run 33520656271 measured 51,604 of 60,342 executable lines (85.51%) at commit 125078474405030d161bd0b287d71339a2d6c0fa by unioning one unit report with all four MySQL feature-shard reports across the complete production source inventory."
     }
 }

--- a/tests/Unit/V2/WorkflowQueryContractTest.php
+++ b/tests/Unit/V2/WorkflowQueryContractTest.php
@@ -230,6 +230,68 @@ final class WorkflowQueryContractTest extends TestCase
         ], $result['validation_errors']);
     }
 
+    public function testItSupportsDurableParametersWithoutCompleteTypeMetadata(): void
+    {
+        $run = $this->runWithQueryContract('partial-type-metadata', [
+            [
+                'name' => 'untyped',
+                'required' => true,
+            ],
+            [
+                'name' => 'empty_type',
+                'type' => '',
+                'required' => true,
+            ],
+            [
+                'name' => 'nullable_short',
+                'type' => '?string',
+                'required' => true,
+            ],
+            [
+                'name' => 'nullable_union',
+                'type' => 'string|null',
+                'required' => true,
+            ],
+            [
+                'name' => 'explicit_nullable',
+                'type' => 'string',
+                'required' => true,
+                'allows_null' => true,
+            ],
+            [
+                'name' => 'mixed_union',
+                'type' => 'int|mixed',
+                'required' => true,
+            ],
+        ]);
+
+        $result = WorkflowQueryContract::validatedArgumentsForRun($run, 'typed-query', [
+            'untyped' => new stdClass(),
+            'empty_type' => null,
+            'nullable_short' => null,
+            'nullable_union' => null,
+            'explicit_nullable' => null,
+            'mixed_union' => [],
+        ]);
+
+        $this->assertSame([], $result['validation_errors']);
+        $this->assertCount(6, $result['arguments']);
+    }
+
+    public function testItUsesTheGenericArgumentNameForMalformedDurableParameters(): void
+    {
+        $run = $this->runWithQueryContract('missing-parameter-name', [[
+            'type' => 'string',
+        ]]);
+
+        $result = WorkflowQueryContract::validatedArgumentsForRun($run, 'typed-query', [123]);
+
+        $this->assertSame([123], $result['arguments']);
+        $this->assertSame([
+            'argument' => ['The argument argument must be of type string.'],
+        ], $result['validation_errors']);
+    }
+
     public function testItUsesSafeFallbacksWhenNoDurableOrLoadableContractExists(): void
     {
         $run = $this->runWithQueryContract('fallback', []);


### PR DESCRIPTION
## Summary

- cover partial durable parameter metadata and malformed unnamed parameters through the public query validator
- raise the accepted coverage floor to the 85.51% result proven by main run 33520656271
- update the coverage contract branch identity from the retired `v2` name to `main`

## Verification

- 8 focused tests / 42 assertions pass with isolated Redis
- Easy Coding Standard passes
- PHPStan passes for the changed test
- coverage-ratchet self-test passes
- public-boundary scan passes

Contributes to #426.