### PR TITLE
Recognize main in coverage contracts

### DIFF
--- a/resources/v2-unit-coverage-contract.json
+++ b/resources/v2-unit-coverage-contract.json
@@ -1,6 +1,6 @@
 {
     "schema_version": 1,
-    "branch": "v2",
+    "branch": "main",
     "measurement": {
         "metric": "line",
         "test_suite": "unit",
@@ -16,6 +16,6 @@
     },
     "provenance": {
         "observed_at": "2026-09-01",
-        "evidence": "The local unit-only command retains the existing 60.00% floor for fast feedback. Public branch qualification uses the combined unit and MySQL feature contract in v2-coverage-contract.json."
+        "evidence": "The local unit-only command retains the existing 60.00% floor for fast feedback. Public main-branch qualification uses the combined unit and MySQL feature contract in v2-coverage-contract.json."
     }
 }

--- a/scripts/ci/check-v2-coverage.php
+++ b/scripts/ci/check-v2-coverage.php
@@ -114,8 +114,8 @@ function summarize_coverage(string $root, array $clovers, array $contract): arra
         fail('Coverage contract schema_version must be 1.');
     }
 
-    if ($branch !== 'v2' || $metric !== 'line' || $suffix !== '.php') {
-        fail('Coverage contract must measure v2 PHP line coverage.');
+    if ($branch !== 'main' || $metric !== 'line' || $suffix !== '.php') {
+        fail('Coverage contract must measure main-branch PHP line coverage.');
     }
 
     if (! is_array($excludedPaths) || $excludedPaths !== []) {
@@ -559,7 +559,7 @@ function self_test(string $root): void
 
     $contract = [
         'schema_version' => 1,
-        'branch' => 'v2',
+        'branch' => 'main',
         'measurement' => [
             'metric' => 'line',
             'test_suite' => 'unit',


### PR DESCRIPTION
## Summary

- align the coverage checker and its self-test with the renamed `main` branch
- align the fast unit-only coverage contract with `main`
- preserve the 100% target, complete source inventory, and raised 85.51% combined baseline

## Root cause

Main run 33523090498 correctly rejected the renamed combined contract because the checker still hard-coded `v2`. The product and database tests all passed; only coverage contract identity failed.

## Verification

- coverage-ratchet self-test passes
- PHP syntax check passes
- both coverage contract JSON files parse
- public-boundary scan passes

Contributes to #426.