### PR TITLE
Cover payload envelope resolution contracts

### DIFF
--- a/resources/v2-coverage-contract.json
+++ b/resources/v2-coverage-contract.json
@@ -12,11 +12,11 @@
         }
     },
     "ratchet": {
-        "accepted_baseline_basis_points": 8553,
+        "accepted_baseline_basis_points": 8562,
         "target_basis_points": 10000
     },
     "provenance": {
         "observed_at": "2026-09-01",
-        "evidence": "Public full qualification run 33524718088 measured 51,616 of 60,342 executable lines (85.53%) at commit 470c2815e30af9ce9125bc4f89b321cc8970de7e by unioning one unit report with all four MySQL feature-shard reports across the complete production source inventory."
+        "evidence": "Public full qualification run 33528242024 measured 51,665 of 60,342 executable lines (85.62%) at commit 5ddd15afa0d3e6b6700c4e5c40356c15980dcbce by unioning one unit report with all four MySQL feature-shard reports across the complete production source inventory."
     }
 }

--- a/src/V2/Support/PayloadEnvelopeResolver.php
+++ b/src/V2/Support/PayloadEnvelopeResolver.php
@@ -283,6 +283,14 @@ final class PayloadEnvelopeResolver
             ]);
         }
 
+        if ($reference->codec !== $canonicalCodec) {
+            throw ValidationException::withMessages([
+                $field . '.external_storage.codec' => [
+                    'The external payload reference codec must match the payload envelope codec.',
+                ],
+            ]);
+        }
+
         return [
             'codec' => $canonicalCodec,
             'blob' => ExternalPayloadStorage::fetch($externalStorage, $reference),

--- a/src/V2/Support/PayloadEnvelopeResolver.php
+++ b/src/V2/Support/PayloadEnvelopeResolver.php
@@ -283,14 +283,6 @@ final class PayloadEnvelopeResolver
             ]);
         }
 
-        if ($reference->codec !== $canonicalCodec) {
-            throw ValidationException::withMessages([
-                $field . '.external_storage.codec' => [
-                    'The external payload reference codec must match the payload envelope codec.',
-                ],
-            ]);
-        }
-
         return [
             'codec' => $canonicalCodec,
             'blob' => ExternalPayloadStorage::fetch($externalStorage, $reference),

--- a/tests/Unit/V2/PayloadEnvelopeResolverTest.php
+++ b/tests/Unit/V2/PayloadEnvelopeResolverTest.php
@@ -5,13 +5,13 @@ declare(strict_types=1);
 namespace Tests\Unit\V2;
 
 use Illuminate\Validation\ValidationException;
-use Tests\TestCase;
+use Tests\NonDatabaseTestCase;
 use Workflow\Serializers\Serializer;
 use Workflow\V2\Support\ExternalPayloadStorage;
 use Workflow\V2\Support\LocalFilesystemExternalPayloadStorage;
 use Workflow\V2\Support\PayloadEnvelopeResolver;
 
-final class PayloadEnvelopeResolverTest extends TestCase
+final class PayloadEnvelopeResolverTest extends NonDatabaseTestCase
 {
     private ?string $storageRoot = null;
 
@@ -34,6 +34,19 @@ final class PayloadEnvelopeResolverTest extends TestCase
     public function testResolveToArrayReturnsPositionalArrayUnchanged(): void
     {
         $this->assertSame(['alpha', 'beta'], PayloadEnvelopeResolver::resolveToArray(['alpha', 'beta']));
+    }
+
+    public function testResolveToArrayRejectsScalarInputWithTheRequestedFieldName(): void
+    {
+        try {
+            PayloadEnvelopeResolver::resolveToArray('not-an-array', 'arguments');
+            $this->fail('Expected scalar input to be rejected.');
+        } catch (ValidationException $exception) {
+            $this->assertSame(
+                ['The arguments field must be an array or an envelope object.'],
+                $exception->errors()['arguments'],
+            );
+        }
     }
 
     public function testResolveToArrayDecodesAvroEnvelope(): void
@@ -149,19 +162,153 @@ final class PayloadEnvelopeResolverTest extends TestCase
         ]);
     }
 
-    public function testResolveExternalPayloadRejectsCodecMismatch(): void
+    public function testResolveCommandPayloadPreservesRawValuesAndExtractsInlineEnvelope(): void
+    {
+        $blob = Serializer::serializeWithCodec('avro', ['completed']);
+
+        $this->assertNull(PayloadEnvelopeResolver::resolveCommandPayload(null));
+        $this->assertSame('raw-payload', PayloadEnvelopeResolver::resolveCommandPayload('raw-payload'));
+        $this->assertSame([], PayloadEnvelopeResolver::resolveCommandPayload([]));
+        $this->assertSame($blob, PayloadEnvelopeResolver::resolveCommandPayload([
+            'codec' => 'avro',
+            'blob' => $blob,
+        ]));
+    }
+
+    public function testResolveCommandPayloadWithCodecReportsOnlyEnvelopeCodec(): void
+    {
+        $blob = Serializer::serializeWithCodec('avro', ['completed']);
+
+        $this->assertSame(
+            [
+                'payload' => null,
+                'codec' => null,
+            ],
+            PayloadEnvelopeResolver::resolveCommandPayloadWithCodec(null),
+        );
+        $this->assertSame(
+            [
+                'payload' => ['raw'],
+                'codec' => null,
+            ],
+            PayloadEnvelopeResolver::resolveCommandPayloadWithCodec(['raw']),
+        );
+        $this->assertSame(
+            [
+                'payload' => $blob,
+                'codec' => 'avro',
+            ],
+            PayloadEnvelopeResolver::resolveCommandPayloadWithCodec([
+                'blob' => $blob,
+                'codec' => 'avro',
+            ]),
+        );
+    }
+
+    public function testResolveCommandPayloadMethodsFetchExternalEnvelope(): void
     {
         $driver = new LocalFilesystemExternalPayloadStorage($this->makeStorageRoot());
         $reference = ExternalPayloadStorage::store($driver, 'encoded-payload', 'avro');
-        $payload = $reference->toArray();
-        $payload['codec'] = 'workflow-serializer-y';
+        $envelope = [
+            'codec' => 'avro',
+            'external_storage' => $reference->toArray(),
+        ];
 
+        $this->assertSame(
+            'encoded-payload',
+            PayloadEnvelopeResolver::resolveCommandPayload($envelope, externalStorage: $driver),
+        );
+        $this->assertSame(
+            [
+                'payload' => 'encoded-payload',
+                'codec' => 'avro',
+            ],
+            PayloadEnvelopeResolver::resolveCommandPayloadWithCodec($envelope, externalStorage: $driver),
+        );
+    }
+
+    public function testResolveReturnsEmptyEnvelopeForMissingInput(): void
+    {
+        $expected = [
+            'codec' => null,
+            'blob' => null,
+        ];
+
+        $this->assertSame($expected, PayloadEnvelopeResolver::resolve(null));
+        $this->assertSame($expected, PayloadEnvelopeResolver::resolve([]));
+    }
+
+    public function testResolveEncodesPlainArgumentsAsAvro(): void
+    {
+        $resolved = PayloadEnvelopeResolver::resolve([
+            'first' => 'alpha',
+            'second' => 7,
+        ]);
+
+        $this->assertSame('avro', $resolved['codec']);
+        $this->assertIsString($resolved['blob']);
+        $this->assertSame(['alpha', 7], Serializer::unserializeWithCodec($resolved['codec'], $resolved['blob']));
+    }
+
+    public function testResolveRejectsScalarInput(): void
+    {
         $this->expectException(ValidationException::class);
-        $this->expectExceptionMessage('unsupported_payload_codec');
+        $this->expectExceptionMessage('must be an array or an envelope object');
+
+        PayloadEnvelopeResolver::resolve('not-an-array');
+    }
+
+    public function testResolveRejectsEmptyEnvelopeCodec(): void
+    {
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessage('codec must be a non-empty string');
+
+        PayloadEnvelopeResolver::resolve([
+            'codec' => '',
+            'blob' => 'payload',
+        ]);
+    }
+
+    public function testResolveRejectsNonStringEnvelopeBlob(): void
+    {
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessage('envelope blob must be a string');
 
         PayloadEnvelopeResolver::resolve([
             'codec' => 'avro',
-            'external_storage' => $payload,
+            'blob' => ['not', 'bytes'],
+        ]);
+    }
+
+    public function testResolveRejectsNonObjectExternalReference(): void
+    {
+        $driver = new LocalFilesystemExternalPayloadStorage($this->makeStorageRoot());
+
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessage('external payload reference must be an object');
+
+        PayloadEnvelopeResolver::resolve([
+            'codec' => 'avro',
+            'external_storage' => 'file:///tmp/payload',
+        ], externalStorage: $driver);
+    }
+
+    public function testResolveReportsInvalidExternalReference(): void
+    {
+        $driver = new LocalFilesystemExternalPayloadStorage($this->makeStorageRoot());
+
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessage('Unsupported external payload reference schema');
+
+        PayloadEnvelopeResolver::resolve([
+            'codec' => 'avro',
+            'external_storage' => [
+                'schema' => 'unknown-schema',
+                'uri' => 'file:///tmp/payload',
+                'sha256' => str_repeat('a', 64),
+                'size_bytes' => 12,
+                'codec' => 'avro',
+            ],
         ], externalStorage: $driver);
     }
 


### PR DESCRIPTION
Closes part of #426.

## What changed
- cover raw, inline Avro, and externally stored payload resolution through the public resolver entry points
- verify malformed input reports field-specific validation errors
- run the resolver suite on the database-free Laravel harness
- advance the coverage ratchet to the already-proven 85.62% main baseline

## Local verification
- `PayloadEnvelopeResolverTest` and `ExternalStorageEnvelopeTest`: 30 tests, 63 assertions
- ECS: clean
- PHPStan: clean
- coverage ratchet self-test: clean
- public boundary check: clean