### PR TITLE
Cover portable failure restoration contracts

### DIFF
--- a/resources/v2-coverage-contract.json
+++ b/resources/v2-coverage-contract.json
@@ -12,11 +12,11 @@
         }
     },
     "ratchet": {
-        "accepted_baseline_basis_points": 8562,
+        "accepted_baseline_basis_points": 8567,
         "target_basis_points": 10000
     },
     "provenance": {
         "observed_at": "2026-09-01",
-        "evidence": "Public full qualification run 33528242024 measured 51,665 of 60,342 executable lines (85.62%) at commit 5ddd15afa0d3e6b6700c4e5c40356c15980dcbce by unioning one unit report with all four MySQL feature-shard reports across the complete production source inventory."
+        "evidence": "Public full qualification run 33530783780 measured 51,701 of 60,342 executable lines (85.67%) at commit 8475c4edbfcd3eb3238e8d9539b54ad1e697d5b4 by unioning one unit report with all four MySQL feature-shard reports across the complete production source inventory."
     }
 }

--- a/tests/Unit/V2/FailureCategoryTest.php
+++ b/tests/Unit/V2/FailureCategoryTest.php
@@ -63,6 +63,17 @@ final class FailureCategoryTest extends NonDatabaseTestCase
         $this->assertSame(FailureCategory::Activity, $category);
     }
 
+    public function testActivityStructuralLimitKeepsStructuralLimitCategory(): void
+    {
+        $category = FailureFactory::classify(
+            'activity',
+            'activity_execution',
+            StructuralLimitExceededException::payloadSize(65, 64),
+        );
+
+        $this->assertSame(FailureCategory::StructuralLimit, $category);
+    }
+
     public function testChildPropagationClassifiesAsChildWorkflow(): void
     {
         $category = FailureFactory::classify('child', 'child_workflow_run', new RuntimeException('child failed'));
@@ -316,6 +327,18 @@ final class FailureCategoryTest extends NonDatabaseTestCase
         $this->assertSame(FailureCategory::Internal, $category);
     }
 
+    public function testClassifyFromStringsRecognizesLoadedExceptionSubclass(): void
+    {
+        $category = FailureFactory::classifyFromStrings(
+            'terminal',
+            'workflow_run',
+            FailureCategoryPdoException::class,
+            'database connection failed',
+        );
+
+        $this->assertSame(FailureCategory::Internal, $category);
+    }
+
     public function testClassifyFromStringsMaxAttemptsAsInternal(): void
     {
         $category = FailureFactory::classifyFromStrings(
@@ -550,4 +573,8 @@ final class FailureCategoryTest extends NonDatabaseTestCase
     {
         $this->assertFalse(FailureFactory::isNonRetryableFromStrings('App\\Exceptions\\DeletedExceptionClass'));
     }
+}
+
+final class FailureCategoryPdoException extends PDOException
+{
 }

--- a/tests/Unit/V2/FailureFactoryRestoreTest.php
+++ b/tests/Unit/V2/FailureFactoryRestoreTest.php
@@ -7,9 +7,13 @@ namespace Tests\Unit\V2;
 use ArgumentCountError;
 use Error;
 use Exception;
+use ReflectionProperty;
 use RuntimeException;
+use Tests\Fixtures\V2\TestAbstractReplayedException;
 use Tests\NonDatabaseTestCase;
 use TypeError;
+use Workflow\Serializers\AvroBinaryValue;
+use Workflow\Serializers\AvroMapValue;
 use Workflow\Serializers\Serializer;
 use Workflow\V2\Enums\StructuralLimitKind;
 use Workflow\V2\Exceptions\RestoredWorkflowException;
@@ -133,5 +137,255 @@ final class FailureFactoryRestoreTest extends NonDatabaseTestCase
         $this->assertInstanceOf(RestoredWorkflowException::class, $restored);
         $this->assertSame('cancel_flight typed compensation failure', $restored->getMessage());
         $this->assertSame('TypedCancelFlightError', $restored->failurePayload()['type'] ?? null);
+    }
+
+    public function testRestoreRehydratesKnownThrowableAndFallsBackForUnrestorableClasses(): void
+    {
+        $restored = FailureFactory::restore([
+            'class' => RuntimeException::class,
+            'message' => 'known runtime failure',
+            'code' => 17,
+            'properties' => 'malformed legacy properties',
+        ]);
+
+        $this->assertInstanceOf(RuntimeException::class, $restored);
+        $this->assertSame('known runtime failure', $restored->getMessage());
+        $this->assertSame(17, $restored->getCode());
+
+        $abstract = FailureFactory::restore([
+            'class' => TestAbstractReplayedException::class,
+            'message' => 'abstract failure',
+            'code' => 0,
+        ]);
+
+        $this->assertInstanceOf(RestoredWorkflowException::class, $abstract);
+        $this->assertSame(TestAbstractReplayedException::class, $abstract->failurePayload()['class']);
+
+        $missing = FailureFactory::restore([
+            'class' => 'App\\Exceptions\\RemovedWorkflowException',
+            'message' => 'removed failure',
+            'code' => 0,
+        ]);
+
+        $this->assertInstanceOf(RestoredWorkflowException::class, $missing);
+        $this->assertSame('removed failure', $missing->getMessage());
+    }
+
+    public function testExternalWorkerStringFailureUsesFallbackMetadata(): void
+    {
+        $restored = FailureFactory::restoreExternalWorkerFailure(
+            'worker failed before returning structured details',
+            RuntimeException::class,
+            'unused fallback message',
+            23,
+        );
+
+        $payload = $restored->failurePayload();
+
+        $this->assertSame(RuntimeException::class, $payload['class']);
+        $this->assertSame('worker failed before returning structured details', $payload['message']);
+        $this->assertSame(23, $payload['code']);
+    }
+
+    public function testRestoreAcceptsAvroEncodedFailurePayload(): void
+    {
+        $payload = FailureFactory::payload(new RuntimeException('encoded failure', 41));
+        $blob = Serializer::serializeWithCodec('avro', $payload);
+
+        $restored = FailureFactory::restoreForReplay($blob);
+
+        $this->assertInstanceOf(RuntimeException::class, $restored);
+        $this->assertSame('encoded failure', $restored->getMessage());
+        $this->assertSame(41, $restored->getCode());
+    }
+
+    public function testFailurePayloadPreservesPortableCustomStateAndSkipsUnsupportedState(): void
+    {
+        $payload = FailureFactory::payload(new PortableFailureStateException());
+        $properties = array_column($payload['properties'], 'value', 'name');
+
+        $this->assertSame(PortableFailureState::Waiting->name, $properties['state']);
+        $this->assertInstanceOf(AvroBinaryValue::class, $properties['binary']);
+        $this->assertSame("\x00\xff", $properties['binary']->bytes);
+        $this->assertInstanceOf(AvroMapValue::class, $properties['metadata']);
+        $this->assertSame(7.0, $properties['ratio']);
+        $this->assertSame('loose value', $properties['loose']);
+        $this->assertNull($properties['nullable']);
+
+        foreach ([
+            'uninitialized',
+            'unsupported',
+            'unsupportedMap',
+            'invalidKeyedArray',
+            'invalidNestedArray',
+            'nonFinite',
+        ] as $omittedProperty) {
+            $this->assertArrayNotHasKey($omittedProperty, $properties);
+        }
+
+        $decoded = Serializer::unserializeWithCodec('avro', Serializer::serializeWithCodec('avro', $payload));
+        $restored = FailureFactory::restoreForReplay($decoded);
+
+        $this->assertInstanceOf(PortableFailureStateException::class, $restored);
+        $this->assertSame(PortableFailureState::Waiting, $restored->state);
+        $this->assertSame("\x00\xff", $restored->binary->bytes);
+        $this->assertEquals(
+            [
+                'state' => PortableFailureState::Waiting->name,
+                'binary' => AvroBinaryValue::fromBytes("\x10\xfe"),
+            ],
+            $restored->metadata,
+        );
+        $this->assertEquals(
+            [PortableFailureState::Complete->name, AvroBinaryValue::fromBytes("\x20\xfd")],
+            $restored->items,
+        );
+        $this->assertSame(7.0, $restored->ratio);
+        $this->assertSame('loose value', $restored->loose);
+        $this->assertNull($restored->nullable);
+
+        foreach ([
+            'uninitialized',
+            'unsupported',
+            'unsupportedMap',
+            'invalidKeyedArray',
+            'invalidNestedArray',
+            'nonFinite',
+        ] as $property) {
+            $this->assertFalse((new ReflectionProperty($restored, $property))->isInitialized($restored));
+        }
+    }
+
+    public function testRestoreToleratesStaleAndMalformedCustomPropertyFrames(): void
+    {
+        $restored = FailureFactory::restore([
+            'class' => PortableFailureStateException::class,
+            'message' => 'stale property metadata',
+            'code' => 0,
+            'properties' => [
+                [
+                    'declaring_class' => 123,
+                    'name' => false,
+                    'value' => 'ignored',
+                ],
+                [
+                    'declaring_class' => \stdClass::class,
+                    'name' => 'nullable',
+                ],
+                [
+                    'declaring_class' => PortableFailureStateException::class,
+                    'name' => 'renamedProperty',
+                    'value' => 'old value',
+                ],
+                [
+                    'declaring_class' => PortableFailureStateException::class,
+                    'name' => 'state',
+                    'value' => 'RemovedCase',
+                ],
+                [
+                    'declaring_class' => PortableFailureStateException::class,
+                    'name' => 'loose',
+                    'value' => 'restored loose value',
+                ],
+            ],
+        ]);
+
+        $this->assertInstanceOf(PortableFailureStateException::class, $restored);
+        $this->assertNull($restored->nullable);
+        $this->assertSame('restored loose value', $restored->loose);
+        $this->assertFalse((new ReflectionProperty($restored, 'state'))->isInitialized($restored));
+    }
+
+    public function testExternalWorkerFailurePreservesDiagnosticMaps(): void
+    {
+        $restored = FailureFactory::restoreExternalWorkerFailure([
+            'class' => RuntimeException::class,
+            'message' => 'diagnosed worker failure',
+            'diagnostics' => [
+                'attempt' => 3,
+            ],
+            'runtime_diagnostics' => [
+                'worker_id' => 'worker-7',
+            ],
+        ]);
+
+        $payload = $restored->failurePayload();
+
+        $this->assertSame([
+            'attempt' => 3,
+        ], $payload['diagnostics']);
+        $this->assertSame([
+            'worker_id' => 'worker-7',
+        ], $payload['runtime_diagnostics']);
+    }
+}
+
+enum PortableFailureState
+{
+    case Waiting;
+    case Complete;
+}
+
+final class PortableFailureStateException extends RuntimeException
+{
+    public string $uninitialized;
+
+    public PortableFailureState $state;
+
+    public AvroBinaryValue $binary;
+
+    public mixed $metadata;
+
+    /**
+     * @var list<mixed>
+     */
+    public array $items;
+
+    public float $ratio;
+
+    public mixed $unsupported;
+
+    public AvroMapValue $unsupportedMap;
+
+    /**
+     * @var array<int|string, string>
+     */
+    public array $invalidKeyedArray;
+
+    /**
+     * @var array<string, mixed>
+     */
+    public array $invalidNestedArray;
+
+    public float $nonFinite;
+
+    public $loose;
+
+    public ?string $nullable;
+
+    public function __construct()
+    {
+        parent::__construct('portable failure state', 29);
+
+        $this->state = PortableFailureState::Waiting;
+        $this->binary = AvroBinaryValue::fromBytes("\x00\xff");
+        $this->metadata = AvroMapValue::fromPairs([
+            ['state', PortableFailureState::Waiting],
+            ['binary', AvroBinaryValue::fromBytes("\x10\xfe")],
+        ]);
+        $this->items = [PortableFailureState::Complete, AvroBinaryValue::fromBytes("\x20\xfd")];
+        $this->ratio = 7.0;
+        $this->unsupported = new \stdClass();
+        $this->unsupportedMap = AvroMapValue::fromPairs([['unsupported', new \stdClass()]]);
+        $this->invalidKeyedArray = [
+            1 => 'integer key',
+            'valid' => 'string key',
+        ];
+        $this->invalidNestedArray = [
+            'unsupported' => new \stdClass(),
+        ];
+        $this->nonFinite = INF;
+        $this->loose = 'loose value';
+        $this->nullable = null;
     }
 }


### PR DESCRIPTION
Closes part of #426.

## What changed
- cover known, missing, and unrestorable exception class restoration
- verify external-worker string failures retain fallback class and code metadata
- prove Avro-encoded failure payload restoration
- cover portable enum, binary, map, list, float, nullable, and diagnostic properties
- verify unsupported or stale custom properties are omitted or ignored without blocking replay
- cover structural activity failures and loaded exception-subclass classification
- advance the coverage ratchet to the proven 85.67% main baseline

## Local verification
- focused failure suites: 73 tests, 159 assertions
- ECS: clean
- PHPStan: clean
- coverage ratchet self-test: clean
- public boundary check: clean