### PR TITLE
Restore classless failures safely

### DIFF
--- a/resources/v2-coverage-contract.json
+++ b/resources/v2-coverage-contract.json
@@ -12,11 +12,11 @@
         }
     },
     "ratchet": {
-        "accepted_baseline_basis_points": 8567,
+        "accepted_baseline_basis_points": 8579,
         "target_basis_points": 10000
     },
     "provenance": {
         "observed_at": "2026-09-01",
-        "evidence": "Public full qualification run 33530783780 measured 51,701 of 60,342 executable lines (85.67%) at commit 8475c4edbfcd3eb3238e8d9539b54ad1e697d5b4 by unioning one unit report with all four MySQL feature-shard reports across the complete production source inventory."
+        "evidence": "Public full qualification run 33532883509 measured 51,772 of 60,342 executable lines (85.79%) at commit cbe4fecea5153732c12feefcb8822719904d0432 by unioning one unit report with all four MySQL feature-shard reports across the complete production source inventory."
     }
 }

--- a/src/V2/Support/FailureFactory.php
+++ b/src/V2/Support/FailureFactory.php
@@ -536,7 +536,11 @@ final class FailureFactory
         $properties = [];
         $reflection = new ReflectionClass($throwable);
 
-        while ($reflection->getName() !== Exception::class && $reflection->getName() !== Error::class) {
+        while (
+            $reflection !== false
+            && $reflection->getName() !== Exception::class
+            && $reflection->getName() !== Error::class
+        ) {
             if (! $reflection->isInternal()) {
                 foreach ($reflection->getProperties() as $property) {
                     if ($property->isStatic() || $property->getDeclaringClass()->getName() !== $reflection->getName()) {
@@ -564,10 +568,6 @@ final class FailureFactory
             }
 
             $reflection = $reflection->getParentClass();
-
-            if ($reflection === false) {
-                break;
-            }
         }
 
         return $properties;
@@ -682,7 +682,7 @@ final class FailureFactory
 
     /**
      * @return array{
-     *     class: class-string<Throwable>|string,
+     *     class: class-string<Throwable>|string|null,
      *     type: string|null,
      *     message: string,
      *     code: int,
@@ -712,7 +712,7 @@ final class FailureFactory
         $normalized = [
             'class' => is_string($payload['class'] ?? null)
                 ? $payload['class']
-                : ($fallbackClass ?? RestoredWorkflowException::class),
+                : $fallbackClass,
             'type' => is_string($payload['type'] ?? null)
                 ? $payload['type']
                 : $fallbackType,

--- a/tests/Unit/V2/FailureFactoryRestoreTest.php
+++ b/tests/Unit/V2/FailureFactoryRestoreTest.php
@@ -18,6 +18,7 @@ use Workflow\Serializers\Serializer;
 use Workflow\V2\Enums\StructuralLimitKind;
 use Workflow\V2\Exceptions\RestoredWorkflowException;
 use Workflow\V2\Exceptions\StructuralLimitExceededException;
+use Workflow\V2\Exceptions\UnresolvedWorkflowFailureException;
 use Workflow\V2\Support\FailureFactory;
 
 final class FailureFactoryRestoreTest extends NonDatabaseTestCase
@@ -169,6 +170,58 @@ final class FailureFactoryRestoreTest extends NonDatabaseTestCase
 
         $this->assertInstanceOf(RestoredWorkflowException::class, $missing);
         $this->assertSame('removed failure', $missing->getMessage());
+    }
+
+    public function testRestoreUsesAValidWrapperWhenFailureClassMetadataIsMissing(): void
+    {
+        $restored = FailureFactory::restore([
+            'message' => 'classless worker failure',
+            'code' => 31,
+        ]);
+
+        $this->assertInstanceOf(RestoredWorkflowException::class, $restored);
+        $this->assertSame('classless worker failure', $restored->getMessage());
+        $this->assertSame(31, $restored->getCode());
+        $this->assertNull($restored->failurePayload()['class']);
+        $this->assertSame(RestoredWorkflowException::class, $restored->originalExceptionClass());
+    }
+
+    public function testReplayResolutionReportsMissingFailureClassAsUnresolved(): void
+    {
+        $this->assertSame([
+            'class' => null,
+            'source' => 'unresolved',
+            'error' => null,
+        ], FailureFactory::replayResolution([
+            'message' => 'classless replay failure',
+        ]));
+    }
+
+    public function testReplayRejectsFailureWithoutClassMetadata(): void
+    {
+        $this->expectException(UnresolvedWorkflowFailureException::class);
+
+        FailureFactory::restoreForReplay([
+            'message' => 'classless replay failure',
+        ]);
+    }
+
+    public function testLiveRestoreFallsBackToRecordedClassWhenTypeMappingIsInvalid(): void
+    {
+        config()->set('workflows.v2.types.exceptions', [
+            'broken.failure' => \stdClass::class,
+        ]);
+
+        $restored = FailureFactory::restore([
+            'class' => RuntimeException::class,
+            'type' => 'broken.failure',
+            'message' => 'recover with recorded class',
+            'code' => 37,
+        ]);
+
+        $this->assertInstanceOf(RuntimeException::class, $restored);
+        $this->assertSame('recover with recorded class', $restored->getMessage());
+        $this->assertSame(37, $restored->getCode());
     }
 
     public function testExternalWorkerStringFailureUsesFallbackMetadata(): void


### PR DESCRIPTION
Closes the remaining `FailureFactory` coverage paths tracked by #426 while fixing a malformed-payload restoration defect.

## What changed

- preserve an absent failure class as `null` instead of treating `RestoredWorkflowException` as an ordinary recorded throwable
- return a fully initialized `RestoredWorkflowException` for live classless failures
- report classless replay failures as unresolved instead of constructing an invalid readonly object
- retain the recorded-class fallback when a configured logical failure type is invalid
- express the throwable-parent termination guard in the traversal condition
- advance the accepted coverage baseline to the verified 85.79% main result

## Verification

- 77 focused tests, 169 assertions
- ECS: pass
- focused PHPStan: pass
- coverage ratchet self-test: pass
- public boundary scan: pass
- `git diff --check`: pass

Full repository qualification is delegated to the required GitHub checks, which install dependencies from the lockfile.