### PR TITLE
Cover workflow exception contracts

### DIFF
--- a/resources/v2-coverage-contract.json
+++ b/resources/v2-coverage-contract.json
@@ -12,11 +12,11 @@
         }
     },
     "ratchet": {
-        "accepted_baseline_basis_points": 8579,
+        "accepted_baseline_basis_points": 8581,
         "target_basis_points": 10000
     },
     "provenance": {
         "observed_at": "2026-09-01",
-        "evidence": "Public full qualification run 33532883509 measured 51,772 of 60,342 executable lines (85.79%) at commit cbe4fecea5153732c12feefcb8822719904d0432 by unioning one unit report with all four MySQL feature-shard reports across the complete production source inventory."
+        "evidence": "Public full qualification run 33534931468 measured 51,782 of 60,342 executable lines (85.81%) at commit 5655a9af0e7ce9309099366309dbb5c6a595b76a by unioning one unit report with all four MySQL feature-shard reports across the complete production source inventory."
     }
 }

--- a/tests/Unit/V2/WorkflowExceptionContractsTest.php
+++ b/tests/Unit/V2/WorkflowExceptionContractsTest.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\V2;
+
+use Tests\NonDatabaseTestCase;
+use Workflow\V2\Enums\StructuralLimitKind;
+use Workflow\V2\Exceptions\DurableOperationCancelledException;
+use Workflow\V2\Exceptions\RestoredWorkflowException;
+use Workflow\V2\Exceptions\StraightLineWorkflowRequiredException;
+use Workflow\V2\Exceptions\StructuralLimitExceededException;
+use Workflow\V2\Exceptions\UnresolvedWorkflowFailureException;
+use Workflow\V2\Exceptions\UnsupportedBackendCapabilitiesException;
+use Workflow\V2\Support\DurableOperationHandle;
+use Workflow\V2\Support\FailureFactory;
+use Workflow\V2\Support\TimerCall;
+
+final class WorkflowExceptionContractsTest extends NonDatabaseTestCase
+{
+    public function testInvalidTypeMappingFallsBackToAWrapperForMissingRecordedClass(): void
+    {
+        config()->set('workflows.v2.types.exceptions', [
+            'broken.failure' => \stdClass::class,
+        ]);
+
+        $restored = FailureFactory::restore([
+            'class' => 'App\\Exceptions\\RemovedWorkflowException',
+            'type' => 'broken.failure',
+            'message' => 'missing recorded failure class',
+        ]);
+
+        $this->assertInstanceOf(RestoredWorkflowException::class, $restored);
+        $this->assertSame('App\\Exceptions\\RemovedWorkflowException', $restored->originalExceptionClass());
+        $this->assertSame('missing recorded failure class', $restored->getMessage());
+    }
+
+    public function testUnresolvedFailureExposesItsPortablePayload(): void
+    {
+        $payload = [
+            'message' => 'class metadata unavailable',
+            'code' => 19,
+        ];
+
+        $exception = UnresolvedWorkflowFailureException::unresolved($payload);
+
+        $this->assertSame($payload, $exception->failurePayload());
+        $this->assertSame('unknown', $exception->originalExceptionClass());
+        $this->assertNull($exception->exceptionType());
+        $this->assertSame('unresolved', $exception->resolutionSource());
+    }
+
+    public function testStraightLineCallbackFailureNamesTheCallbackContract(): void
+    {
+        $exception = StraightLineWorkflowRequiredException::forCallback();
+
+        $this->assertSame(
+            'Workflow v2 callbacks must use straight-line helpers and must not yield.',
+            $exception->getMessage(),
+        );
+    }
+
+    public function testUnsupportedBackendCapabilityMessagesHandleEmptyAndMalformedIssues(): void
+    {
+        $empty = new UnsupportedBackendCapabilitiesException([]);
+        $malformed = new UnsupportedBackendCapabilitiesException([
+            'issues' => ['not an issue map'],
+        ]);
+
+        $this->assertSame('Workflow v2 backend capabilities are unsupported.', $empty->getMessage());
+        $this->assertSame('Workflow v2 backend capabilities are unsupported.', $malformed->getMessage());
+        $this->assertSame([
+            'issues' => ['not an issue map'],
+        ], $malformed->snapshot());
+    }
+
+    public function testPendingTimerLimitCarriesPortableMetadata(): void
+    {
+        $exception = StructuralLimitExceededException::pendingTimerCount(81, 80);
+
+        $this->assertSame(StructuralLimitKind::PendingTimerCount, $exception->limitKind);
+        $this->assertSame(81, $exception->currentValue);
+        $this->assertSame(80, $exception->configuredLimit);
+        $this->assertSame('Structural limit exceeded: 81 pending timers (limit 80).', $exception->getMessage());
+    }
+
+    public function testDurableCancellationRetainsSelectedHandleIdentity(): void
+    {
+        $handle = new DurableOperationHandle(
+            key: 'timer-key',
+            index: 2,
+            kind: 'timer',
+            identity: 'timer:2',
+            baseSequence: 7,
+            size: 1,
+            selectionGroupId: 'selection-1',
+            call: new TimerCall(30),
+        );
+
+        $exception = DurableOperationCancelledException::forHandle($handle);
+
+        $this->assertSame('selection-1', $exception->selectionGroupId);
+        $this->assertSame('timer-key', $exception->memberKey);
+        $this->assertSame(2, $exception->memberIndex);
+        $this->assertSame('timer', $exception->operationKind);
+        $this->assertSame('timer:2', $exception->operationIdentity);
+        $this->assertSame('Durable timer operation [timer:2] was cancelled.', $exception->getMessage());
+    }
+
+    public function testDurableCancellationCanRepresentAnUnselectedOperation(): void
+    {
+        $exception = DurableOperationCancelledException::forOperation('activity', 'activity:9');
+
+        $this->assertNull($exception->selectionGroupId);
+        $this->assertNull($exception->memberKey);
+        $this->assertNull($exception->memberIndex);
+        $this->assertSame('activity', $exception->operationKind);
+        $this->assertSame('activity:9', $exception->operationIdentity);
+        $this->assertSame('Durable activity operation [activity:9] was cancelled.', $exception->getMessage());
+    }
+}


### PR DESCRIPTION
Continues #426 with one cohesive, test-only exception-surface slice.

## Covered behavior

- invalid logical failure mappings with unavailable recorded classes
- restored and unresolved failure identity/payload accessors
- straight-line callback diagnostics
- empty and malformed backend-capability issue lists
- pending-timer structural-limit metadata
- selected and unselected durable-operation cancellation identity
- the final uncovered `FailureFactory` fallback

The accepted coverage baseline advances to the verified 85.81% main result. No production source or exclusion list changes are included.

## Verification

- 25 focused tests, 114 assertions
- ECS: pass
- focused PHPStan: pass
- coverage ratchet self-test: pass
- public boundary scan: pass
- `git diff --check`: pass