### PR TITLE
Harden offline bundle integrity diagnostics

### DIFF
--- a/resources/v2-coverage-contract.json
+++ b/resources/v2-coverage-contract.json
@@ -12,11 +12,11 @@
         }
     },
     "ratchet": {
-        "accepted_baseline_basis_points": 8623,
+        "accepted_baseline_basis_points": 8638,
         "target_basis_points": 10000
     },
     "provenance": {
         "observed_at": "2026-09-02",
-        "evidence": "Public full qualification run 33574671208 measured 52,041 of 60,345 executable lines (86.23%) at commit a0e7fd2b6590d28ccac13a07418f0d23fc21b132 by unioning one unit report with all four MySQL feature-shard reports across the complete production source inventory."
+        "evidence": "Public full qualification run 33576043908 measured 52,132 of 60,345 executable lines (86.38%) at commit adbc88dbd1f8254e3b4e79085ff68ee1e1d881ba by unioning one unit report with all four MySQL feature-shard reports across the complete production source inventory."
     }
 }

--- a/src/V2/Support/BundleIntegrityVerifier.php
+++ b/src/V2/Support/BundleIntegrityVerifier.php
@@ -400,6 +400,14 @@ final class BundleIntegrityVerifier
 
         foreach ($entries as $index => $entry) {
             if (! is_array($entry)) {
+                self::addFinding(
+                    $findings,
+                    'payload_manifest.entry_invalid',
+                    self::SEVERITY_ERROR,
+                    'Payload manifest entry must be an object.',
+                    "payload_manifest.entries[{$index}]",
+                );
+
                 continue;
             }
 
@@ -628,6 +636,14 @@ final class BundleIntegrityVerifier
 
         foreach ($commands as $index => $command) {
             if (! is_array($command)) {
+                self::addFinding(
+                    $findings,
+                    'commands.entry_invalid',
+                    self::SEVERITY_ERROR,
+                    'Command row must be an object.',
+                    "commands[{$index}]",
+                );
+
                 continue;
             }
 
@@ -789,7 +805,7 @@ final class BundleIntegrityVerifier
 
         try {
             $canonical = self::canonicalJson($unsignedBundle);
-        } catch (LogicException $exception) {
+        } catch (JsonException|LogicException $exception) {
             self::addFinding(
                 $findings,
                 'integrity.canonicalization_failed',

--- a/tests/Unit/V2/BundleIntegrityVerifierTest.php
+++ b/tests/Unit/V2/BundleIntegrityVerifierTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\Unit\V2;
 
 use Tests\NonDatabaseTestCase;
+use Workflow\Serializers\Avro;
 use Workflow\V2\Support\BundleIntegrityVerifier;
 use Workflow\V2\Support\HistoryExport;
 use Workflow\V2\Support\MemoPayload;
@@ -276,6 +277,76 @@ final class BundleIntegrityVerifierTest extends NonDatabaseTestCase
         $this->assertSame(BundleIntegrityVerifier::STATUS_FAILED, $report['status']);
     }
 
+    public function testMalformedPayloadManifestEntriesAndMissingCodecMetadataAreReported(): void
+    {
+        $bundle = self::wellFormedBundle();
+        $bundle['payload_manifest']['entries'] = [
+            'not-an-object',
+            [
+                'available' => false,
+            ],
+            [
+                'path' => 'payloads.arguments.data',
+                'codec' => 'avro',
+                'available' => true,
+                'redacted' => false,
+                'diagnostic' => null,
+            ],
+        ];
+        $bundle['integrity'] = self::buildIntegrity($bundle);
+
+        $report = BundleIntegrityVerifier::verify($bundle);
+
+        $this->assertSame(BundleIntegrityVerifier::STATUS_FAILED, $report['status']);
+        $this->assertSame(
+            'payload_manifest.entries[0]',
+            $this->finding($report, 'payload_manifest.entry_invalid')['path'],
+        );
+        $this->assertSame(
+            'payload_manifest.entries[1]',
+            $this->finding($report, 'payload_manifest.codec_missing')['path'],
+        );
+        $this->assertSame(
+            'payloads.arguments.data',
+            $this->finding($report, 'payload_manifest.avro_framing_missing')['path'],
+        );
+    }
+
+    public function testBundledAvroSchemaMustBePresentAndMatchTheRuntime(): void
+    {
+        $bundle = self::wellFormedBundle();
+        $bundle['codec_schemas']['avro'] = [
+            'current_fingerprint' => 'missing',
+            'writer_schemas' => [],
+        ];
+        $bundle['integrity'] = self::buildIntegrity($bundle);
+
+        $missingReport = BundleIntegrityVerifier::verify($bundle);
+
+        $this->assertSame(BundleIntegrityVerifier::STATUS_FAILED, $missingReport['status']);
+        $this->finding($missingReport, 'codec_schemas.value_schema_missing');
+
+        $fingerprint = Avro::valueSchemaFingerprint();
+        $bundle['codec_schemas']['avro'] = [
+            'current_fingerprint' => $fingerprint,
+            'writer_schemas' => [
+                $fingerprint => [
+                    'schema' => '{}',
+                    'fingerprint' => 'crc64-avro:incorrect',
+                ],
+            ],
+        ];
+        $bundle['integrity'] = self::buildIntegrity($bundle);
+
+        $driftReport = BundleIntegrityVerifier::verify($bundle);
+
+        $this->assertSame(BundleIntegrityVerifier::STATUS_FAILED, $driftReport['status']);
+        $this->assertStringEndsWith(
+            $fingerprint,
+            (string) $this->finding($driftReport, 'codec_schemas.value_schema_drift')['path'],
+        );
+    }
+
     public function testWriterSchemaFingerprintMismatchIsReported(): void
     {
         $bundle = self::wellFormedBundle();
@@ -317,6 +388,136 @@ final class BundleIntegrityVerifierTest extends NonDatabaseTestCase
         $rules = array_column($report['findings'], 'rule');
         $this->assertContains('commands.history_event_missing', $rules);
         $this->assertSame(BundleIntegrityVerifier::STATUS_WARNING, $report['status']);
+    }
+
+    public function testMalformedHistoryAndCommandRowsAreReported(): void
+    {
+        $bundle = self::wellFormedBundle();
+        unset($bundle['history_events'][0]['type']);
+        $bundle['history_events'][] = 'not-an-object';
+        $bundle['commands'][] = 'not-an-object';
+        $bundle['integrity'] = self::buildIntegrity($bundle);
+
+        $report = BundleIntegrityVerifier::verify($bundle);
+
+        $this->assertSame(BundleIntegrityVerifier::STATUS_FAILED, $report['status']);
+        $this->assertSame('history_events[0]', $this->finding($report, 'history_events.type_missing')['path']);
+        $this->assertSame('history_events[2]', $this->finding($report, 'history_events.entry_invalid')['path']);
+        $this->assertSame('commands[1]', $this->finding($report, 'commands.entry_invalid')['path']);
+    }
+
+    public function testAppliedRedactionWithoutPathsIsSummarizedAsInformation(): void
+    {
+        $bundle = self::wellFormedBundle();
+        $bundle['redaction']['applied'] = true;
+        $bundle['integrity'] = self::buildIntegrity($bundle);
+
+        $report = BundleIntegrityVerifier::verify($bundle);
+
+        $this->assertSame(BundleIntegrityVerifier::STATUS_OK, $report['status']);
+        $this->assertSame(1, $report['summary']['info']);
+        $this->assertSame(
+            BundleIntegrityVerifier::SEVERITY_INFO,
+            $this->finding($report, 'redaction.empty_paths')['severity'],
+        );
+    }
+
+    public function testUnsupportedIntegrityMetadataAndMissingValuesAreReported(): void
+    {
+        config()->set('workflows.v2.history_export.signing_key', null);
+
+        $cases = [
+            'integrity.canonicalization_unsupported' => static function (array &$integrity): void {
+                $integrity['canonicalization'] = 'unknown';
+            },
+            'integrity.checksum_algorithm_unsupported' => static function (array &$integrity): void {
+                $integrity['checksum_algorithm'] = 'md5';
+            },
+            'integrity.checksum_missing' => static function (array &$integrity): void {
+                unset($integrity['checksum']);
+            },
+            'integrity.signature_algorithm_unsupported' => static function (array &$integrity): void {
+                $integrity['signature_algorithm'] = 'rsa-sha256';
+                $integrity['signature'] = 'signature';
+            },
+            'integrity.signature_missing' => static function (array &$integrity): void {
+                $integrity['signature_algorithm'] = 'hmac-sha256';
+                $integrity['signature'] = null;
+            },
+            'integrity.signature_key_unavailable' => static function (array &$integrity): void {
+                $integrity['signature_algorithm'] = 'hmac-sha256';
+                $integrity['signature'] = 'signature';
+            },
+        ];
+
+        foreach ($cases as $rule => $mutate) {
+            $bundle = self::wellFormedBundle();
+            $mutate($bundle['integrity']);
+
+            $report = BundleIntegrityVerifier::verify($bundle);
+
+            $this->finding($report, $rule);
+            $this->assertSame(
+                $rule === 'integrity.signature_key_unavailable'
+                    ? BundleIntegrityVerifier::STATUS_WARNING
+                    : BundleIntegrityVerifier::STATUS_FAILED,
+                $report['status'],
+                $rule,
+            );
+        }
+    }
+
+    public function testInvalidUtf8ProducesACanonicalizationFindingInsteadOfEscaping(): void
+    {
+        $bundle = self::wellFormedBundle();
+        $bundle['workflow']['workflow_type'] = "\xB1\x31";
+
+        $report = BundleIntegrityVerifier::verify($bundle);
+
+        $this->assertSame(BundleIntegrityVerifier::STATUS_FAILED, $report['status']);
+        $this->assertStringContainsString(
+            'Malformed UTF-8',
+            $this->finding($report, 'integrity.canonicalization_failed')['message'],
+        );
+        $this->assertNull($report['integrity']['recomputed_checksum']);
+    }
+
+    public function testConfiguredSigningKeyIsTrimmedAndUsedWhenNoExplicitKeyIsProvided(): void
+    {
+        $bundle = self::wellFormedBundle();
+        unset($bundle['integrity']);
+        $canonicalJson = json_encode(
+            self::canonicalize($bundle),
+            JSON_UNESCAPED_SLASHES | JSON_PRESERVE_ZERO_FRACTION | JSON_THROW_ON_ERROR,
+        );
+        $key = 'history-export-secret';
+        $bundle['integrity'] = [
+            'canonicalization' => 'json-recursive-ksort-v1',
+            'checksum_algorithm' => 'sha256',
+            'checksum' => hash('sha256', $canonicalJson),
+            'signature_algorithm' => 'hmac-sha256',
+            'signature' => hash_hmac('sha256', $canonicalJson, $key),
+            'key_id' => 'configured-key',
+        ];
+        config()
+            ->set('workflows.v2.history_export.signing_key', "  {$key}  ");
+
+        $report = BundleIntegrityVerifier::verify($bundle);
+
+        $this->assertSame(BundleIntegrityVerifier::STATUS_OK, $report['status']);
+        $this->assertTrue($report['integrity']['signature_verified']);
+    }
+
+    public function testNumericStringSchemaVersionIsNormalizedInTheReport(): void
+    {
+        $bundle = self::wellFormedBundle();
+        $bundle['schema_version'] = (string) HistoryExport::SCHEMA_VERSION;
+        $bundle['integrity'] = self::buildIntegrity($bundle);
+
+        $report = BundleIntegrityVerifier::verify($bundle);
+
+        $this->assertSame(BundleIntegrityVerifier::STATUS_OK, $report['status']);
+        $this->assertSame(HistoryExport::SCHEMA_VERSION, $report['bundle']['schema_version']);
     }
 
     public function testSignatureVerifiesWhenKeyMatches(): void


### PR DESCRIPTION
## Summary

- reject malformed payload-manifest and command rows instead of silently skipping them
- turn invalid UTF-8 canonicalization failures into a structured verifier finding
- cover Avro schema metadata, malformed history rows, redaction summaries, checksum/signature failures, configured signing keys, and numeric schema versions
- advance the non-decreasing coverage floor to the latest exact `main` measurement

## Validation

- `phpunit tests/Unit/V2/BundleIntegrityVerifierTest.php` (30 tests, 98 assertions)
- focused PHPStan analysis
- focused ECS check
- `scripts/check-public-boundary.sh`

Advances #426.