### PR TITLE
Cover replay verification command paths

### DIFF
--- a/resources/v2-coverage-contract.json
+++ b/resources/v2-coverage-contract.json
@@ -12,11 +12,11 @@
         }
     },
     "ratchet": {
-        "accepted_baseline_basis_points": 8638,
+        "accepted_baseline_basis_points": 8661,
         "target_basis_points": 10000
     },
     "provenance": {
         "observed_at": "2026-09-02",
-        "evidence": "Public full qualification run 33576043908 measured 52,132 of 60,345 executable lines (86.38%) at commit adbc88dbd1f8254e3b4e79085ff68ee1e1d881ba by unioning one unit report with all four MySQL feature-shard reports across the complete production source inventory."
+        "evidence": "Public full qualification run 33577365322 measured 52,278 of 60,359 executable lines (86.61%) at commit cba33c487db1531cd920ff260afe21479820ea96 by unioning one unit report with all four MySQL feature-shard reports across the complete production source inventory."
     }
 }

--- a/tests/Feature/V2/V2ReplayDiffTest.php
+++ b/tests/Feature/V2/V2ReplayDiffTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Feature\V2;
 
+use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Queue;
 use Tests\Fixtures\V2\TestGreetingWorkflow;
 use Tests\TestCase;
@@ -47,6 +48,24 @@ final class V2ReplayDiffTest extends TestCase
         $this->assertNull($report['divergence']);
         $this->assertNull($report['error']);
         $this->assertIsInt($report['replay']['sequence']);
+
+        $path = tempnam(sys_get_temp_dir(), 'replay-verify-command-');
+        $this->assertIsString($path);
+        file_put_contents($path, json_encode($bundle, JSON_THROW_ON_ERROR));
+        $this->beforeApplicationDestroyed(static function () use ($path): void {
+            if (is_file($path)) {
+                unlink($path);
+            }
+        });
+
+        $exitCode = Artisan::call('workflow:v2:replay-verify', [
+            'bundle' => $path,
+        ]);
+        $output = Artisan::output();
+
+        $this->assertSame(0, $exitCode, $output);
+        $this->assertStringContainsString('Replay verification: OK', $output);
+        $this->assertStringContainsString('Replay: status=replayed reason=none', $output);
     }
 
     public function testReplayDiffSurfacesShapeMismatchAsDrift(): void

--- a/tests/Unit/Commands/V2ReplayVerifyCommandTest.php
+++ b/tests/Unit/Commands/V2ReplayVerifyCommandTest.php
@@ -5,12 +5,12 @@ declare(strict_types=1);
 namespace Tests\Unit\Commands;
 
 use Illuminate\Support\Str;
-use Tests\TestCase;
+use Tests\NonDatabaseTestCase;
 use Workflow\V2\Support\BundleIntegrityVerifier;
 use Workflow\V2\Support\HistoryExport;
 use Workflow\V2\Support\MemoPayload;
 
-final class V2ReplayVerifyCommandTest extends TestCase
+final class V2ReplayVerifyCommandTest extends NonDatabaseTestCase
 {
     public function testCommandSucceedsForWellFormedBundleWithSkipReplay(): void
     {
@@ -132,6 +132,66 @@ final class V2ReplayVerifyCommandTest extends TestCase
         ])
             ->expectsOutputToContain('"verdict": "ok"')
             ->assertSuccessful();
+    }
+
+    public function testHumanReportRendersWarningAndUnverifiedSignature(): void
+    {
+        config()->set('workflows.v2.history_export.signing_key', null);
+        $bundle = self::wellFormedBundle();
+        $bundle['integrity']['signature_algorithm'] = 'hmac-sha256';
+        $bundle['integrity']['signature'] = 'unverified-signature';
+        $bundle['integrity']['key_id'] = 'unavailable-key';
+        $bundlePath = $this->writeBundle($bundle);
+
+        $this->artisan('workflow:v2:replay-verify', [
+            'bundle' => $bundlePath,
+            '--skip-replay' => true,
+        ])
+            ->expectsOutputToContain('Replay verification: WARNING')
+            ->expectsOutputToContain('Workflow: run=cli-test-run instance=cli-test-instance events=2')
+            ->expectsOutputToContain('Integrity: status=warning checksum_match=yes signature=n/a')
+            ->expectsOutputToContain('[WARNING] integrity.signature_key_unavailable')
+            ->assertSuccessful();
+    }
+
+    public function testHumanReportRendersChecksumFailure(): void
+    {
+        $bundle = self::wellFormedBundle();
+        $bundle['integrity']['checksum'] = str_repeat('0', 64);
+        $bundlePath = $this->writeBundle($bundle);
+
+        $this->artisan('workflow:v2:replay-verify', [
+            'bundle' => $bundlePath,
+            '--skip-replay' => true,
+        ])
+            ->expectsOutputToContain('Replay verification: FAILED')
+            ->expectsOutputToContain('Integrity: status=failed checksum_match=no signature=unsigned')
+            ->expectsOutputToContain('[ERROR] integrity.checksum_mismatch')
+            ->assertFailed();
+    }
+
+    public function testHumanReportRendersReplayFailure(): void
+    {
+        $bundlePath = $this->writeBundle(self::wellFormedBundle());
+
+        $this->artisan('workflow:v2:replay-verify', [
+            'bundle' => $bundlePath,
+        ])
+            ->expectsOutputToContain('Replay verification: FAILED')
+            ->expectsOutputToContain('Replay: status=failed reason=')
+            ->expectsOutputToContain('Error:')
+            ->assertFailed();
+    }
+
+    public function testMissingBundleFailureIsRenderedForHumans(): void
+    {
+        $path = '/nonexistent/path/' . Str::ulid() . '.json';
+
+        $this->artisan('workflow:v2:replay-verify', [
+            'bundle' => $path,
+        ])
+            ->expectsOutputToContain("Bundle file [{$path}] does not exist.")
+            ->assertFailed();
     }
 
     /**


### PR DESCRIPTION
## Summary

- exercise human-readable warning, checksum failure, replay failure, missing-file, and clean live-replay output
- move command-only tests onto the non-database harness
- advance the non-decreasing coverage floor to the latest exact `main` measurement

## Validation

- replay command unit suite (9 tests, 48 assertions)
- MySQL-backed direct and command replay journey (1 test, 12 assertions)
- regression-corpus policy validation against `main`
- focused ECS check
- `scripts/check-public-boundary.sh`

Advances #426.