### PR TITLE
Cover workflow scheduling option contracts

### DIFF
--- a/resources/v2-coverage-contract.json
+++ b/resources/v2-coverage-contract.json
@@ -12,11 +12,11 @@
         }
     },
     "ratchet": {
-        "accepted_baseline_basis_points": 8661,
+        "accepted_baseline_basis_points": 8674,
         "target_basis_points": 10000
     },
     "provenance": {
         "observed_at": "2026-09-02",
-        "evidence": "Public full qualification run 33577365322 measured 52,278 of 60,359 executable lines (86.61%) at commit cba33c487db1531cd920ff260afe21479820ea96 by unioning one unit report with all four MySQL feature-shard reports across the complete production source inventory."
+        "evidence": "Public full qualification run 33581395929 measured 52,361 of 60,359 executable lines (86.74%) at commit a03509a515bf149ee27f4971171820c34f01370e by unioning one unit report with all four MySQL feature-shard reports across the complete production source inventory."
     }
 }

--- a/tests/Unit/V2/ActivityOptionsTest.php
+++ b/tests/Unit/V2/ActivityOptionsTest.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\V2;
+
+use PHPUnit\Framework\TestCase;
+use Workflow\V2\Support\ActivityOptions;
+use Workflow\V2\Support\WorkerSessionOptions;
+
+final class ActivityOptionsTest extends TestCase
+{
+    public function testSchedulingBuildersAreImmutableAndPreserveActivityOverrides(): void
+    {
+        $session = new WorkerSessionOptions(
+            sessionId: 'gpu-render',
+            connection: 'redis',
+            queue: 'gpu',
+            requirements: ['gpu:nvidia-l4'],
+            leaseSeconds: 120,
+            ttlSeconds: 600,
+            maxConcurrentActivities: 1,
+        );
+        $original = new ActivityOptions(
+            connection: 'sqs',
+            queue: 'images',
+            maxAttempts: 3,
+            backoff: [1, 5],
+            startToCloseTimeout: 300,
+            scheduleToStartTimeout: 30,
+            scheduleToCloseTimeout: 600,
+            heartbeatTimeout: 20,
+            nonRetryableErrorTypes: ['InvalidImage'],
+            workerSession: $session,
+        );
+
+        $prioritized = $original->withPriority(2);
+        $rebalanced = $prioritized->withFairness('Tenant-A', 4);
+
+        $this->assertFalse($original->hasSchedulingOverrides());
+        $this->assertTrue($prioritized->hasSchedulingOverrides());
+        $this->assertTrue($rebalanced->hasSchedulingOverrides());
+        $this->assertNull($original->priority);
+        $this->assertSame(2, $prioritized->priority);
+        $this->assertSame('tenant-a', $rebalanced->fairnessKey);
+        $this->assertSame(4, $rebalanced->fairnessWeight);
+        $this->assertNotSame($original, $prioritized);
+        $this->assertNotSame($prioritized, $rebalanced);
+        $this->assertSame([
+            'connection' => 'sqs',
+            'queue' => 'images',
+            'max_attempts' => 3,
+            'backoff' => [1, 5],
+            'start_to_close_timeout' => 300,
+            'schedule_to_start_timeout' => 30,
+            'schedule_to_close_timeout' => 600,
+            'heartbeat_timeout' => 20,
+            'non_retryable_error_types' => ['InvalidImage'],
+            'worker_session' => $session->toSnapshot(),
+            'priority' => 2,
+            'fairness_key' => 'tenant-a',
+            'fairness_weight' => 4,
+        ], $rebalanced->toSnapshot());
+    }
+
+    public function testSchedulingBuildersCanClearAllOverrides(): void
+    {
+        $options = (new ActivityOptions(priority: 2, fairnessKey: 'tenant-a', fairnessWeight: 4))
+            ->withPriority(null)
+            ->withFairness(null);
+
+        $this->assertNull($options->priority);
+        $this->assertNull($options->fairnessKey);
+        $this->assertNull($options->fairnessWeight);
+        $this->assertFalse($options->hasSchedulingOverrides());
+    }
+}

--- a/tests/Unit/V2/StartOptionsTest.php
+++ b/tests/Unit/V2/StartOptionsTest.php
@@ -8,6 +8,7 @@ use LogicException;
 use PHPUnit\Framework\TestCase;
 use Workflow\V2\Enums\DuplicateStartPolicy;
 use Workflow\V2\StartOptions;
+use Workflow\V2\Support\TaskPriority;
 use Workflow\V2\Support\WorkflowInstanceId;
 
 final class StartOptionsTest extends TestCase
@@ -175,6 +176,26 @@ final class StartOptionsTest extends TestCase
         ]);
     }
 
+    public function testNonScalarLabelValueThrows(): void
+    {
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('must be a scalar value or null');
+
+        new StartOptions(labels: [
+            'tenant' => ['acme'],
+        ]);
+    }
+
+    public function testEmptyLabelValueThrows(): void
+    {
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('must be a non-empty string');
+
+        new StartOptions(labels: [
+            'tenant' => '   ',
+        ]);
+    }
+
     // ---------------------------------------------------------------
     //  Memo validation
     // ---------------------------------------------------------------
@@ -227,6 +248,16 @@ final class StartOptionsTest extends TestCase
 
         new StartOptions(memo: [
             '' => 'value',
+        ]);
+    }
+
+    public function testNonJsonMemoValueThrows(): void
+    {
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('JSON-like scalars');
+
+        new StartOptions(memo: [
+            'request' => new \stdClass(),
         ]);
     }
 
@@ -305,6 +336,58 @@ final class StartOptionsTest extends TestCase
 
         new StartOptions(searchAttributes: [
             'invalid key' => 'value',
+        ]);
+    }
+
+    public function testUnsupportedSearchAttributeValueThrows(): void
+    {
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('scalar value, string list, or null');
+
+        new StartOptions(searchAttributes: [
+            'owner' => new \stdClass(),
+        ]);
+    }
+
+    public function testAssociativeSearchAttributeListThrows(): void
+    {
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('must be a JSON array');
+
+        new StartOptions(searchAttributes: [
+            'owners' => [
+                'primary' => 'Taylor',
+            ],
+        ]);
+    }
+
+    public function testNonStringSearchAttributeListEntryThrows(): void
+    {
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('must contain only strings');
+
+        new StartOptions(searchAttributes: [
+            'owners' => ['Taylor', 42],
+        ]);
+    }
+
+    public function testOverlongSearchAttributeListEntryThrows(): void
+    {
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('list values must be up to');
+
+        new StartOptions(searchAttributes: [
+            'owners' => [str_repeat('a', WorkflowInstanceId::MAX_LENGTH + 1)],
+        ]);
+    }
+
+    public function testOverlongScalarSearchAttributeThrows(): void
+    {
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('must be up to');
+
+        new StartOptions(searchAttributes: [
+            'owner' => str_repeat('a', WorkflowInstanceId::MAX_LENGTH + 1),
         ]);
     }
 
@@ -431,6 +514,59 @@ final class StartOptionsTest extends TestCase
 
         $this->assertSame(100, $original->runTimeoutSeconds);
         $this->assertSame(200, $modified->runTimeoutSeconds);
+    }
+
+    public function testSchedulingBuildersAreImmutableAndPreserveOtherFields(): void
+    {
+        $original = new StartOptions(
+            businessKey: 'order-789',
+            labels: [
+                'tenant' => 'acme',
+            ],
+            memo: [
+                'source' => 'checkout',
+            ],
+            searchAttributes: [
+                'region' => 'west',
+            ],
+            executionTimeoutSeconds: 3600,
+            runTimeoutSeconds: 1800,
+            priority: 7,
+            fairnessKey: 'Tenant-A',
+            fairnessWeight: 2,
+        );
+
+        $prioritized = $original->withPriority(1);
+        $rebalanced = $prioritized->withFairness('Tenant-B', 4);
+
+        $this->assertSame(7, $original->priority);
+        $this->assertSame('tenant-a', $original->fairnessKey);
+        $this->assertSame(2, $original->fairnessWeight);
+        $this->assertSame(1, $prioritized->priority);
+        $this->assertSame('tenant-a', $prioritized->fairnessKey);
+        $this->assertSame(2, $prioritized->fairnessWeight);
+        $this->assertSame(1, $rebalanced->priority);
+        $this->assertSame('tenant-b', $rebalanced->fairnessKey);
+        $this->assertSame(4, $rebalanced->fairnessWeight);
+        $this->assertSame($prioritized->businessKey, $rebalanced->businessKey);
+        $this->assertSame($prioritized->labels, $rebalanced->labels);
+        $this->assertSame($prioritized->memo, $rebalanced->memo);
+        $this->assertSame($prioritized->searchAttributes, $rebalanced->searchAttributes);
+        $this->assertSame($prioritized->executionTimeoutSeconds, $rebalanced->executionTimeoutSeconds);
+        $this->assertSame($prioritized->runTimeoutSeconds, $rebalanced->runTimeoutSeconds);
+        $this->assertNotSame($original, $prioritized);
+        $this->assertNotSame($prioritized, $rebalanced);
+    }
+
+    public function testSchedulingBuildersCanRestoreDefaults(): void
+    {
+        $options = (new StartOptions(priority: 1, fairnessKey: 'tenant-a', fairnessWeight: 3))
+            ->withPriority(null)
+            ->withFairness(null);
+
+        $this->assertSame(TaskPriority::DEFAULT, $options->priority);
+        $this->assertNull($options->fairnessKey);
+        $this->assertSame(1, $options->fairnessWeight);
     }
 
     public function testBuilderChainPreservesAllFields(): void


### PR DESCRIPTION
## Summary

- cover immutable workflow and activity priority/fairness builders, including preservation of routing, retry, timeout, and worker-session settings
- cover the remaining invalid label, memo, and search-attribute validation branches in `StartOptions`
- advance the nondecreasing coverage ratchet to the already-proven 86.74% public-main baseline from run 33581395929

## Validation

- 49 focused tests, 116 assertions
- Easy Coding Standard on changed PHP files
- `git diff --check`
- public-boundary check

Advances #426.