### PR TITLE
Prepare Workflow 2.0.3 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+## 2.0.3 - 2026-09-02
+
+- Schedule ticks share bounded due-work and buffered-drain batches across
+  namespaces while preserving oldest-first order within each namespace.
+
 ## 2.0.2 - 2026-09-01
 
 - Workflow `2.0.2` reports its stable package identity through the platform

--- a/composer.json
+++ b/composer.json
@@ -79,7 +79,7 @@
             "dev-main": "2.0.x-dev"
         },
         "durable-workflow": {
-            "product-train": "2.0.2",
+            "product-train": "2.0.3",
             "laravel-embedded-upgrade-contract": "resources/laravel-embedded-upgrade-contract.json",
             "laravel-dependency-security-policy": "resources/laravel-dependency-security-policy.json"
         },


### PR DESCRIPTION
## Summary

- declare the package source identity as `2.0.3`
- record namespace-fair bounded schedule batches in the changelog

## Verification

- `composer validate --no-check-publish`
- focused platform source-release contract: 1 test, 42 assertions
- full `main` build for scheduler commit `9c0ea2c0` is green