### PR TITLE
Cover portable workflow metadata contracts

### DIFF
--- a/src/V2/StartOptions.php
+++ b/src/V2/StartOptions.php
@@ -6,6 +6,7 @@ namespace Workflow\V2;
 
 use LogicException;
 use Workflow\V2\Enums\DuplicateStartPolicy;
+use Workflow\V2\Models\WorkflowSearchAttribute;
 use Workflow\V2\Support\TaskFairnessKey;
 use Workflow\V2\Support\TaskPriority;
 use Workflow\V2\Support\WorkflowInstanceId;
@@ -365,11 +366,11 @@ final class StartOptions
 
                     $trimmed = trim($entry);
 
-                    if ($trimmed !== '' && strlen($trimmed) > WorkflowInstanceId::MAX_LENGTH) {
+                    if ($trimmed !== '' && mb_strlen($trimmed) > WorkflowSearchAttribute::MAX_KEYWORD_LENGTH) {
                         throw new LogicException(sprintf(
                             'Workflow v2 search attribute [%s] list values must be up to %d characters.',
                             $key,
-                            WorkflowInstanceId::MAX_LENGTH,
+                            WorkflowSearchAttribute::MAX_KEYWORD_LENGTH,
                         ));
                     }
 
@@ -385,11 +386,11 @@ final class StartOptions
                 $value
             ) : (string) $value);
 
-            if ($stringValue !== '' && strlen($stringValue) > WorkflowInstanceId::MAX_LENGTH) {
+            if ($stringValue !== '' && mb_strlen($stringValue) > WorkflowSearchAttribute::MAX_STRING_LENGTH) {
                 throw new LogicException(sprintf(
                     'Workflow v2 search attribute [%s] must be up to %d characters when cast to string.',
                     $key,
-                    WorkflowInstanceId::MAX_LENGTH,
+                    WorkflowSearchAttribute::MAX_STRING_LENGTH,
                 ));
             }
 

--- a/src/V2/Support/UpsertSearchAttributesCall.php
+++ b/src/V2/Support/UpsertSearchAttributesCall.php
@@ -66,7 +66,7 @@ final class UpsertSearchAttributesCall implements YieldedCommand
 
                     $trimmed = trim($entry);
 
-                    if (strlen($trimmed) > WorkflowSearchAttribute::MAX_KEYWORD_LENGTH) {
+                    if (mb_strlen($trimmed) > WorkflowSearchAttribute::MAX_KEYWORD_LENGTH) {
                         throw new LogicException(sprintf(
                             'Workflow v2 search attribute [%s] list values must be up to %d characters.',
                             $key,
@@ -85,11 +85,11 @@ final class UpsertSearchAttributesCall implements YieldedCommand
             if (is_string($value)) {
                 $trimmed = trim($value);
 
-                if (strlen($trimmed) > WorkflowSearchAttribute::MAX_KEYWORD_LENGTH) {
+                if (mb_strlen($trimmed) > WorkflowSearchAttribute::MAX_STRING_LENGTH) {
                     throw new LogicException(sprintf(
                         'Workflow v2 search attribute [%s] must be up to %d characters.',
                         $key,
-                        WorkflowSearchAttribute::MAX_KEYWORD_LENGTH,
+                        WorkflowSearchAttribute::MAX_STRING_LENGTH,
                     ));
                 }
 

--- a/tests/Unit/V2/MemoReplayIdentityTest.php
+++ b/tests/Unit/V2/MemoReplayIdentityTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Tests\Unit\V2;
 
+use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Workflow\Serializers\AvroBinaryValue;
 use Workflow\Serializers\AvroMapValue;
@@ -13,6 +15,25 @@ use Workflow\V2\Support\MemoReplayIdentity;
 
 final class MemoReplayIdentityTest extends TestCase
 {
+    public function testCanonicalEnvelopeNormalizesNestedMapOrder(): void
+    {
+        $canonical = MemoPayload::canonicalEnvelope(MemoPayload::envelope([
+            'second' => [
+                'right' => 2,
+                'left' => 1,
+            ],
+            'first' => true,
+        ]));
+
+        $this->assertSame(MemoPayload::envelope([
+            'first' => true,
+            'second' => [
+                'left' => 1,
+                'right' => 2,
+            ],
+        ]), $canonical);
+    }
+
     public function testEmptyMemoMapRetainsItsAvroMapBranch(): void
     {
         $envelope = MemoPayload::mapEnvelope([]);
@@ -107,5 +128,78 @@ final class MemoReplayIdentityTest extends TestCase
                 'payload' => AvroBinaryValue::fromBytes('same-bytes'),
             ],
         );
+    }
+
+    public function testMapPayloadHelpersPreservePortableBytes(): void
+    {
+        $map = AvroMapValue::fromPairs([['payload', AvroBinaryValue::fromBytes("\x00\xFF")]]);
+        $envelope = MemoPayload::envelope($map);
+
+        $this->assertSame($envelope, MemoPayload::canonicalMapEnvelope($envelope));
+        $this->assertSame("\x00\xFF", MemoPayload::decodeEntries($envelope)['payload']->bytes);
+        $this->assertNotSame('', MemoPayload::encodedBytes($map));
+        $this->assertNotSame('', MemoPayload::encodedMapBytes([
+            'payload' => AvroBinaryValue::fromBytes("\x00\xFF"),
+        ]));
+    }
+
+    public function testMemoEntryPayloadRejectsInvalidKeys(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('invalid_memo_key');
+
+        MemoPayload::decodeEntries(MemoPayload::envelope(AvroMapValue::fromPairs([['123', 'value']])));
+    }
+
+    public function testMemoEntryPayloadMustBeAMap(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('must decode to a string-keyed map');
+
+        MemoPayload::decodeEntries(MemoPayload::envelope(['value']));
+    }
+
+    /**
+     * @param array<string, mixed> $envelope
+     */
+    #[DataProvider('invalidEnvelopes')]
+    public function testMalformedMemoEnvelopesAreRejected(array $envelope, string $message): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage($message);
+
+        MemoPayload::encodedEnvelopeSize($envelope);
+    }
+
+    /**
+     * @return iterable<string, array{array<string, mixed>, string}>
+     */
+    public static function invalidEnvelopes(): iterable
+    {
+        yield 'nonstandard shape' => [[
+            'codec' => 'avro',
+            'blob' => 'value',
+            'extra' => true,
+        ], 'expected exactly the standard'];
+        yield 'unsupported codec' => [[
+            'codec' => 'json',
+            'blob' => 'value',
+        ], 'unsupported_payload_codec'];
+        yield 'non-string codec' => [[
+            'codec' => [],
+            'blob' => 'value',
+        ], 'memo payloads require codec "avro"'];
+        yield 'empty blob' => [[
+            'codec' => 'avro',
+            'blob' => '',
+        ], 'must be a non-empty string'];
+        yield 'non-string blob' => [[
+            'codec' => 'avro',
+            'blob' => [],
+        ], 'must be a non-empty string'];
+        yield 'invalid base64 blob' => [[
+            'codec' => 'avro',
+            'blob' => '%%%',
+        ], 'must be strict base64'];
     }
 }

--- a/tests/Unit/V2/SearchAttributeReplayIdentityTest.php
+++ b/tests/Unit/V2/SearchAttributeReplayIdentityTest.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\V2;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Workflow\V2\Exceptions\HistoryEventShapeMismatchException;
+use Workflow\V2\Support\SearchAttributeReplayIdentity;
+use Workflow\V2\Support\UpsertSearchAttributesCall;
+
+final class SearchAttributeReplayIdentityTest extends TestCase
+{
+    public function testReorderedValuesAndTypesRetainReplayIdentity(): void
+    {
+        $current = new UpsertSearchAttributesCall([
+            'status' => 'ready',
+            'attempt' => 2,
+        ]);
+
+        SearchAttributeReplayIdentity::assertCompatible(4, [
+            'attributes' => [
+                'status' => 'ready',
+                'attempt' => 2,
+            ],
+            'attribute_types' => [
+                'status' => 'keyword',
+                'attempt' => 'int',
+            ],
+        ], $current);
+
+        $this->addToAssertionCount(1);
+    }
+
+    public function testLegacyValueOnlyHistoryRemainsReplayCompatible(): void
+    {
+        SearchAttributeReplayIdentity::assertCompatible(4, [
+            'attributes' => [
+                'status' => 'ready',
+            ],
+        ], new UpsertSearchAttributesCall([
+            'status' => 'ready',
+        ]));
+
+        $this->addToAssertionCount(1);
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     */
+    #[DataProvider('mismatchedPayloads')]
+    public function testReplayRejectsDifferentValuesOrTypeIdentity(array $payload, string $message): void
+    {
+        $this->expectException(HistoryEventShapeMismatchException::class);
+        $this->expectExceptionMessage($message);
+
+        SearchAttributeReplayIdentity::assertCompatible(
+            7,
+            $payload,
+            new UpsertSearchAttributesCall([
+                'status' => 'ready',
+            ]),
+        );
+    }
+
+    /**
+     * @return iterable<string, array{array<string, mixed>, string}>
+     */
+    public static function mismatchedPayloads(): iterable
+    {
+        yield 'missing attributes' => [[], 'Recorded search attribute values do not match'];
+        yield 'non-map attributes' => [[
+            'attributes' => 'ready',
+        ], 'Recorded search attribute values do not match'];
+        yield 'different values' => [[
+            'attributes' => [
+                'status' => 'waiting',
+            ],
+        ], 'Recorded search attribute values do not match'];
+        yield 'non-map type identity' => [[
+            'attributes' => [
+                'status' => 'ready',
+            ],
+            'attribute_types' => 'keyword',
+        ], 'Recorded search attribute types do not match'];
+        yield 'different type identity' => [[
+            'attributes' => [
+                'status' => 'ready',
+            ],
+            'attribute_types' => [
+                'status' => 'string',
+            ],
+        ], 'Recorded search attribute types do not match'];
+    }
+}

--- a/tests/Unit/V2/SearchAttributeTest.php
+++ b/tests/Unit/V2/SearchAttributeTest.php
@@ -53,6 +53,25 @@ class SearchAttributeTest extends TestCase
         $this->assertEquals('A long description string', $attr->getValue());
     }
 
+    public function testItStoresScalarTextBeyondTheKeywordLimit(): void
+    {
+        $run = $this->createRun();
+        $description = str_repeat("\u{00E9}", WorkflowSearchAttribute::MAX_STRING_LENGTH);
+
+        $this->service->upsert($run, new UpsertSearchAttributesCall([
+            'description' => $description,
+        ]), 1);
+
+        $attribute = WorkflowSearchAttribute::query()
+            ->where('workflow_run_id', $run->id)
+            ->where('key', 'description')
+            ->firstOrFail();
+
+        $this->assertSame(WorkflowSearchAttribute::TYPE_STRING, $attribute->type);
+        $this->assertSame($description, $attribute->value_string);
+        $this->assertSame($description, $attribute->getValue());
+    }
+
     public function testItInfersAndStoresKeywordTypeForShortStrings(): void
     {
         $run = $this->createRun();

--- a/tests/Unit/V2/SearchAttributeValueFilterTest.php
+++ b/tests/Unit/V2/SearchAttributeValueFilterTest.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\V2;
+
+use DateTimeImmutable;
+use Illuminate\Database\Capsule\Manager as Capsule;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Workflow\V2\Support\SearchAttributeValueFilter;
+
+final class SearchAttributeValueFilterTest extends TestCase
+{
+    #[DataProvider('typedValues')]
+    public function testTypedValuesTargetTheirStorageColumns(mixed $value, string $column): void
+    {
+        $query = $this->query('sqlite');
+
+        SearchAttributeValueFilter::apply($query, $value);
+
+        $this->assertStringContainsString('"' . $column . '" = ?', $query->toSql());
+        $this->assertSame([$value], $query->getBindings());
+    }
+
+    /**
+     * @return iterable<string, array{mixed, string}>
+     */
+    public static function typedValues(): iterable
+    {
+        yield 'boolean' => [true, 'value_bool'];
+        yield 'integer' => [42, 'value_int'];
+        yield 'float' => [2.5, 'value_float'];
+        yield 'datetime' => [new DateTimeImmutable('2026-09-04T12:00:00Z'), 'value_datetime'];
+        yield 'long string' => [str_repeat('x', 256), 'value_string'];
+    }
+
+    public function testShortStringsMatchKeywordsOrKeywordListMembersOnSqlite(): void
+    {
+        $query = $this->query('sqlite');
+
+        SearchAttributeValueFilter::apply($query, 'php');
+
+        $this->assertStringContainsString('"value_keyword" = ?', $query->toSql());
+        $this->assertStringContainsString('json_each("value_keyword_list")', $query->toSql());
+        $this->assertSame(['php', 'php'], $query->getBindings());
+    }
+
+    public function testKeywordListsRequireEveryStringMemberOnSqlite(): void
+    {
+        $query = $this->query('sqlite');
+
+        SearchAttributeValueFilter::apply($query, ['php', 42, 'rust']);
+
+        $this->assertSame(2, substr_count($query->toSql(), 'json_each("value_keyword_list")'));
+        $this->assertSame(['php', 'rust'], $query->getBindings());
+    }
+
+    public function testKeywordListsWithoutStringMembersNeverMatch(): void
+    {
+        $query = $this->query('sqlite');
+
+        SearchAttributeValueFilter::apply($query, [42, false]);
+
+        $this->assertStringContainsString('0 = 1', $query->toSql());
+        $this->assertSame([], $query->getBindings());
+    }
+
+    public function testMysqlUsesNativeJsonMembershipForKeywordValuesAndLists(): void
+    {
+        $keyword = $this->query('mysql');
+        SearchAttributeValueFilter::apply($keyword, 'php');
+
+        $list = $this->query('mysql');
+        SearchAttributeValueFilter::apply($list, ['php', 'rust']);
+
+        $this->assertStringContainsString('json_contains(`value_keyword_list`, ?)', $keyword->toSql());
+        $this->assertSame(['php', '"php"'], $keyword->getBindings());
+        $this->assertSame(2, substr_count($list->toSql(), 'json_contains(`value_keyword_list`, ?)'));
+        $this->assertSame(['"php"', '"rust"'], $list->getBindings());
+    }
+
+    private function query(string $driver): Builder
+    {
+        $capsule = new Capsule();
+        $capsule->addConnection([
+            'driver' => $driver,
+            'database' => ':memory:',
+            'prefix' => '',
+        ], $driver);
+        $capsule->setAsGlobal();
+        $capsule->bootEloquent();
+
+        $model = new SearchAttributeFilterModel();
+        $model->setConnection($driver);
+
+        return $model->newQuery();
+    }
+}
+
+final class SearchAttributeFilterModel extends Model
+{
+    public $timestamps = false;
+
+    protected $table = 'workflow_search_attributes';
+}

--- a/tests/Unit/V2/StartOptionsTest.php
+++ b/tests/Unit/V2/StartOptionsTest.php
@@ -7,6 +7,7 @@ namespace Tests\Unit\V2;
 use LogicException;
 use PHPUnit\Framework\TestCase;
 use Workflow\V2\Enums\DuplicateStartPolicy;
+use Workflow\V2\Models\WorkflowSearchAttribute;
 use Workflow\V2\StartOptions;
 use Workflow\V2\Support\TaskPriority;
 use Workflow\V2\Support\WorkflowInstanceId;
@@ -377,8 +378,18 @@ final class StartOptionsTest extends TestCase
         $this->expectExceptionMessage('list values must be up to');
 
         new StartOptions(searchAttributes: [
-            'owners' => [str_repeat('a', WorkflowInstanceId::MAX_LENGTH + 1)],
+            'owners' => [str_repeat('a', WorkflowSearchAttribute::MAX_KEYWORD_LENGTH + 1)],
         ]);
+    }
+
+    public function testLongScalarSearchAttributeUsesTheDocumentedStringLimit(): void
+    {
+        $description = str_repeat("\u{00E9}", WorkflowSearchAttribute::MAX_STRING_LENGTH);
+        $options = new StartOptions(searchAttributes: [
+            'description' => $description,
+        ]);
+
+        $this->assertSame($description, $options->searchAttributes['description']);
     }
 
     public function testOverlongScalarSearchAttributeThrows(): void
@@ -387,7 +398,7 @@ final class StartOptionsTest extends TestCase
         $this->expectExceptionMessage('must be up to');
 
         new StartOptions(searchAttributes: [
-            'owner' => str_repeat('a', WorkflowInstanceId::MAX_LENGTH + 1),
+            'owner' => str_repeat('a', WorkflowSearchAttribute::MAX_STRING_LENGTH + 1),
         ]);
     }
 

--- a/tests/Unit/V2/WorkflowMetadataCommandTest.php
+++ b/tests/Unit/V2/WorkflowMetadataCommandTest.php
@@ -1,0 +1,138 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\V2;
+
+use LogicException;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Workflow\Serializers\AvroBinaryValue;
+use Workflow\V2\Models\WorkflowSearchAttribute;
+use Workflow\V2\Support\UpsertMemoCall;
+use Workflow\V2\Support\UpsertMemosCall;
+use Workflow\V2\Support\UpsertSearchAttributesCall;
+
+final class WorkflowMetadataCommandTest extends TestCase
+{
+    public function testSearchAttributeCommandNormalizesPortableValues(): void
+    {
+        $description = str_repeat("\u{00E9}", WorkflowSearchAttribute::MAX_STRING_LENGTH);
+        $call = new UpsertSearchAttributesCall([
+            'z_value' => '  ',
+            'tags' => [' php ', 'rust'],
+            'priority' => 3,
+            'description' => $description,
+        ]);
+
+        $this->assertSame([
+            'description' => $description,
+            'priority' => 3,
+            'tags' => ['php', 'rust'],
+            'z_value' => null,
+        ], $call->attributes);
+    }
+
+    /**
+     * @param array<mixed> $attributes
+     */
+    #[DataProvider('invalidSearchAttributes')]
+    public function testSearchAttributeCommandRejectsInvalidValues(array $attributes, string $message): void
+    {
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage($message);
+
+        new UpsertSearchAttributesCall($attributes);
+    }
+
+    /**
+     * @return iterable<string, array{array<mixed>, string}>
+     */
+    public static function invalidSearchAttributes(): iterable
+    {
+        yield 'empty update' => [[], 'requires at least one attribute'];
+        yield 'numeric key' => [[
+            0 => 'value',
+        ], 'keys must be 1-64 URL-safe characters'];
+        yield 'invalid key' => [[
+            'not a key' => 'value',
+        ], 'keys must be 1-64 URL-safe characters'];
+        yield 'object value' => [[
+            'owner' => new \stdClass(),
+        ], 'must be a scalar value, string list, or null'];
+        yield 'associative list' => [[
+            'owners' => [
+                'primary' => 'Taylor',
+            ],
+        ], 'list value must be a JSON array'];
+        yield 'non-string list entry' => [[
+            'owners' => ['Taylor', 42],
+        ], 'list values must contain only strings'];
+        yield 'overlong keyword-list entry' => [[
+            'owners' => [str_repeat("\u{00E9}", WorkflowSearchAttribute::MAX_KEYWORD_LENGTH + 1)],
+        ], 'list values must be up to 255 characters'];
+        yield 'overlong scalar string' => [[
+            'description' => str_repeat('a', WorkflowSearchAttribute::MAX_STRING_LENGTH + 1),
+        ], 'must be up to 2048 characters'];
+    }
+
+    public function testMemoCommandsNormalizePortableEntries(): void
+    {
+        $value = AvroBinaryValue::fromBytes("\x00\xFF");
+
+        $this->assertSame([
+            'delete' => null,
+            'payload' => $value,
+        ], (new UpsertMemoCall([
+            'payload' => $value,
+            'delete' => null,
+        ]))->entries);
+
+        $this->assertSame([
+            'delete' => null,
+            'payload' => $value,
+        ], (new UpsertMemosCall([
+            'payload' => $value,
+            'delete' => null,
+        ]))->memos);
+    }
+
+    /**
+     * @param class-string<UpsertMemoCall|UpsertMemosCall> $command
+     */
+    #[DataProvider('memoCommands')]
+    public function testMemoCommandsRejectEmptyAndInvalidEntries(string $command): void
+    {
+        try {
+            new $command([]);
+            $this->fail('Empty memo updates must be rejected.');
+        } catch (LogicException $exception) {
+            $this->assertStringContainsString('requires at least one', $exception->getMessage());
+        }
+
+        try {
+            new $command([
+                '123' => 'value',
+            ]);
+            $this->fail('Non-portable memo keys must be rejected.');
+        } catch (LogicException $exception) {
+            $this->assertStringContainsString('memo keys must match', $exception->getMessage());
+        }
+
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('must be a portable Avro value');
+
+        new $command([
+            'payload' => new \stdClass(),
+        ]);
+    }
+
+    /**
+     * @return iterable<string, array{class-string<UpsertMemoCall|UpsertMemosCall>}>
+     */
+    public static function memoCommands(): iterable
+    {
+        yield 'singular command' => [UpsertMemoCall::class];
+        yield 'legacy plural command' => [UpsertMemosCall::class];
+    }
+}


### PR DESCRIPTION
Closes part of #426.

## Summary

- cover search-attribute command validation, typed SQL filtering, and replay identity
- cover portable memo command validation, canonical map ordering, binary values, and malformed envelopes
- align embedded start/upsert validation with the documented 2,048-character string and 255-character keyword-list limits
- prove full-length multibyte text survives database persistence

## Validation

- focused metadata suite: 92 tests, 191 assertions
- PostgreSQL-backed SearchAttributeTest: 21 tests, 79 assertions
- ECS on all changed files
- PHPStan on all changed files
- public-boundary check
