### PR TITLE
Cover typed search attribute contracts

### DIFF
--- a/src/V2/Models/WorkflowSearchAttribute.php
+++ b/src/V2/Models/WorkflowSearchAttribute.php
@@ -347,7 +347,10 @@ class WorkflowSearchAttribute extends Model
     private function setIntValue(mixed $value): void
     {
         if (! is_numeric($value)) {
-            throw new InvalidArgumentException("Cannot coerce value to int: {$value}");
+            throw new InvalidArgumentException(sprintf(
+                'Cannot coerce value to int: %s',
+                self::describeValue($value),
+            ));
         }
 
         $this->value_int = (int) $value;
@@ -356,7 +359,10 @@ class WorkflowSearchAttribute extends Model
     private function setFloatValue(mixed $value): void
     {
         if (! is_numeric($value)) {
-            throw new InvalidArgumentException("Cannot coerce value to float: {$value}");
+            throw new InvalidArgumentException(sprintf(
+                'Cannot coerce value to float: %s',
+                self::describeValue($value),
+            ));
         }
 
         $this->value_float = (float) $value;
@@ -391,7 +397,10 @@ class WorkflowSearchAttribute extends Model
             }
         }
 
-        throw new InvalidArgumentException("Cannot coerce value to bool: {$value}");
+        throw new InvalidArgumentException(sprintf(
+            'Cannot coerce value to bool: %s',
+            self::describeValue($value),
+        ));
     }
 
     private function setDatetimeValue(mixed $value): void
@@ -440,5 +449,10 @@ class WorkflowSearchAttribute extends Model
         }
 
         throw new InvalidArgumentException('Cannot coerce value to string: ' . gettype($value));
+    }
+
+    private static function describeValue(mixed $value): string
+    {
+        return is_scalar($value) ? (string) $value : get_debug_type($value);
     }
 }

--- a/tests/Unit/V2/SearchAttributeTest.php
+++ b/tests/Unit/V2/SearchAttributeTest.php
@@ -325,6 +325,38 @@ class SearchAttributeTest extends TestCase
         $this->assertEquals(0, WorkflowSearchAttribute::where('workflow_run_id', $run->id)->count());
     }
 
+    public function testItDeletesEveryAttributeForOnlyTheSelectedRun(): void
+    {
+        $selectedRun = $this->createRun();
+        $otherRun = $this->createRun();
+
+        $this->service->upsert($selectedRun, new UpsertSearchAttributesCall([
+            'region' => 'us-east',
+            'priority' => 5,
+        ]), 1);
+        $this->service->upsert($otherRun, new UpsertSearchAttributesCall([
+            'region' => 'eu-west',
+        ]), 1);
+
+        $this->service->deleteAllForRun($selectedRun->id);
+
+        $this->assertSame(0, WorkflowSearchAttribute::where('workflow_run_id', $selectedRun->id)->count());
+        $this->assertSame(1, WorkflowSearchAttribute::where('workflow_run_id', $otherRun->id)->count());
+    }
+
+    public function testItExposesTheOwningRunAndInstanceRelations(): void
+    {
+        $run = $this->createRun();
+        $this->service->upsert($run, new UpsertSearchAttributesCall([
+            'region' => 'us-east',
+        ]), 1);
+
+        $attribute = WorkflowSearchAttribute::where('workflow_run_id', $run->id)->firstOrFail();
+
+        $this->assertTrue($attribute->run->is($run));
+        $this->assertTrue($attribute->instance->is($run->instance));
+    }
+
     public function testItEnforcesMaxAttributesPerRunLimit(): void
     {
         $run = $this->createRun();
@@ -351,6 +383,132 @@ class SearchAttributeTest extends TestCase
             'one_too_many' => 'fail',
         ]);
         $this->service->upsert($run, $call2, 2);
+    }
+
+    public function testModelValidationRejectsPersistedAttributeCountsBeyondTheLimit(): void
+    {
+        $run = $this->createRun();
+        $now = now();
+        $rows = [];
+
+        for ($i = 0; $i <= WorkflowSearchAttribute::MAX_ATTRIBUTES_PER_RUN; $i++) {
+            $rows[] = [
+                'workflow_run_id' => $run->id,
+                'workflow_instance_id' => $run->workflow_instance_id,
+                'key' => "attribute_{$i}",
+                'type' => WorkflowSearchAttribute::TYPE_KEYWORD,
+                'upserted_at_sequence' => 1,
+                'inherited_from_parent' => false,
+                'created_at' => $now,
+                'updated_at' => $now,
+            ];
+        }
+
+        WorkflowSearchAttribute::query()->insert($rows);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Search attributes count exceeds maximum (101 > 100)');
+
+        WorkflowSearchAttribute::validateCount($run->id);
+    }
+
+    public function testTotalSizeValidationAccountsForEveryStorageType(): void
+    {
+        $run = $this->createRun();
+        $this->service->upsert($run, new UpsertSearchAttributesCall([
+            'description' => 'durable workflow',
+            'priority' => 5,
+            'ratio' => 1.5,
+            'active' => true,
+            'started_at' => '2026-09-04T12:00:00Z',
+            'languages' => ['php', 'python', 'rust'],
+        ]), 1, attributeTypes: [
+            'started_at' => WorkflowSearchAttribute::TYPE_DATETIME,
+        ]);
+        WorkflowSearchAttribute::create([
+            'workflow_run_id' => $run->id,
+            'workflow_instance_id' => $run->workflow_instance_id,
+            'key' => 'empty_value',
+            'type' => WorkflowSearchAttribute::TYPE_KEYWORD,
+            'upserted_at_sequence' => 1,
+            'inherited_from_parent' => false,
+        ]);
+
+        WorkflowSearchAttribute::validateTotalSize($run->id);
+
+        $this->addToAssertionCount(1);
+    }
+
+    public function testModelValidationRejectsPersistedAttributeSetsBeyondTheTotalSizeLimit(): void
+    {
+        $run = $this->createRun();
+        $now = now();
+        $rows = [];
+
+        for ($i = 0; $i < 33; $i++) {
+            $rows[] = [
+                'workflow_run_id' => $run->id,
+                'workflow_instance_id' => $run->workflow_instance_id,
+                'key' => "description_{$i}",
+                'type' => WorkflowSearchAttribute::TYPE_STRING,
+                'value_string' => str_repeat('x', WorkflowSearchAttribute::MAX_STRING_LENGTH),
+                'upserted_at_sequence' => 1,
+                'inherited_from_parent' => false,
+                'created_at' => $now,
+                'updated_at' => $now,
+            ];
+        }
+
+        WorkflowSearchAttribute::query()->insert($rows);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Total search attributes size exceeds maximum (67584 > 65536 bytes)');
+
+        WorkflowSearchAttribute::validateTotalSize($run->id);
+    }
+
+    public function testUpsertRejectsAnOversizedCombinedAttributeSetAtomically(): void
+    {
+        $run = $this->createRun();
+        $attributes = [];
+
+        for ($i = 0; $i < 33; $i++) {
+            $attributes["description_{$i}"] = str_repeat('x', WorkflowSearchAttribute::MAX_STRING_LENGTH);
+        }
+
+        try {
+            $this->service->upsert($run, new UpsertSearchAttributesCall($attributes), 1);
+            $this->fail('The oversized attribute set should be rejected.');
+        } catch (InvalidArgumentException $exception) {
+            $this->assertSame(
+                'Total search attributes size exceeds maximum (67584 > 65536 bytes)',
+                $exception->getMessage(),
+            );
+        }
+
+        $this->assertSame(0, WorkflowSearchAttribute::where('workflow_run_id', $run->id)->count());
+    }
+
+    public function testUpsertIgnoresLegacyNullValuesWhenCalculatingTotalSize(): void
+    {
+        $run = $this->createRun();
+        WorkflowSearchAttribute::create([
+            'workflow_run_id' => $run->id,
+            'workflow_instance_id' => $run->workflow_instance_id,
+            'key' => 'empty_value',
+            'type' => WorkflowSearchAttribute::TYPE_KEYWORD,
+            'upserted_at_sequence' => 1,
+            'inherited_from_parent' => false,
+        ]);
+
+        $this->service->upsert($run, new UpsertSearchAttributesCall([
+            'region' => 'us-east',
+        ]), 2);
+
+        $this->assertSame([
+            'empty_value' => null,
+            'region' => 'us-east',
+        ], $this->service->getAttributes($run));
     }
 
     public function testItEnforcesStringLengthLimit(): void

--- a/tests/Unit/V2/VisibilityFiltersTest.php
+++ b/tests/Unit/V2/VisibilityFiltersTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Unit\V2;
 
+use Illuminate\Http\Request;
 use Tests\TestCase;
 use Workflow\V2\Models\WorkflowInstance;
 use Workflow\V2\Models\WorkflowRun;
@@ -14,6 +15,46 @@ use Workflow\V2\Support\VisibilityFilters;
 
 final class VisibilityFiltersTest extends TestCase
 {
+    public function testFromRequestNormalizesCanonicalAndAliasQueryParameters(): void
+    {
+        $request = Request::create('/runs', 'GET', [
+            'namespace' => ' production ',
+            'workflow_type_contains' => ' invoice ',
+            'archived' => 1,
+            'label' => [
+                'tenant' => ' acme ',
+            ],
+            'search_attributes' => [
+                'priority' => ' high ',
+            ],
+        ]);
+
+        $filters = VisibilityFilters::fromRequest($request);
+
+        $this->assertSame('production', $filters['namespace']);
+        $this->assertTrue($filters['archived']);
+        $this->assertSame('invoice', $filters['workflow_type_contains']);
+        $this->assertSame([
+            'tenant' => 'acme',
+        ], $filters['labels']);
+        $this->assertSame([
+            'priority' => 'high',
+        ], $filters['search_attributes']);
+    }
+
+    public function testNormalizeHandlesIntegerBooleansAndRejectsMalformedLabels(): void
+    {
+        $this->assertSame([
+            'archived' => true,
+            'is_terminal' => false,
+        ], VisibilityFilters::normalize([
+            'repair_attention' => 2,
+            'archived' => 1,
+            'is_terminal' => 0,
+            'labels' => 'tenant=acme',
+        ]));
+    }
+
     public function testNormalizeKeepsOnlyVersionedVisibilityFields(): void
     {
         $filters = VisibilityFilters::normalize([
@@ -524,6 +565,63 @@ final class VisibilityFiltersTest extends TestCase
             'This saved view uses visibility filter version 1, but this Waterline build supports version 6.',
             $alphaVersion['message'],
         );
+    }
+
+    public function testVersionMetadataNormalizesStringVersionsAndExplainsMalformedContracts(): void
+    {
+        $supported = VisibilityFilters::versionMetadata(' 6 ');
+        $wrongType = VisibilityFilters::versionMetadata(true);
+        $empty = VisibilityFilters::versionMetadata(' ');
+        $nonNumeric = VisibilityFilters::versionMetadata('v6');
+
+        $this->assertSame(6, $supported['version']);
+        $this->assertTrue($supported['supported']);
+
+        foreach ([$wrongType, $empty, $nonNumeric] as $metadata) {
+            $this->assertNull($metadata['version']);
+            $this->assertFalse($metadata['supported']);
+            $this->assertSame(
+                'This saved view does not declare a supported visibility filter version. '
+                    . 'This Waterline build supports version 6.',
+                $metadata['message'],
+            );
+        }
+    }
+
+    public function testApplyFiltersArchivedTerminalRuns(): void
+    {
+        WorkflowRunSummary::create([
+            'id' => '01JVISARCHIVEDTERMINAL001',
+            'workflow_instance_id' => 'archived-terminal-match',
+            'run_number' => 1,
+            'is_current_run' => true,
+            'engine_source' => 'v2',
+            'class' => 'BillingWorkflow',
+            'workflow_type' => 'billing.invoice-sync',
+            'status' => 'completed',
+            'status_bucket' => 'completed',
+            'archived_at' => now(),
+        ]);
+        WorkflowRunSummary::create([
+            'id' => '01JVISACTIVE0RUNNING000001',
+            'workflow_instance_id' => 'active-running-miss',
+            'run_number' => 1,
+            'is_current_run' => true,
+            'engine_source' => 'v2',
+            'class' => 'BillingWorkflow',
+            'workflow_type' => 'billing.invoice-sync',
+            'status' => 'running',
+            'status_bucket' => 'running',
+            'archived_at' => null,
+        ]);
+
+        $ids = VisibilityFilters::apply(WorkflowRunSummary::query(), [
+            'archived' => true,
+            'is_terminal' => true,
+        ])->pluck('id')
+            ->all();
+
+        $this->assertSame(['01JVISARCHIVEDTERMINAL001'], $ids);
     }
 
     public function testIsReservedViewIdGuardsSystemPrefix(): void

--- a/tests/Unit/V2/WorkflowSearchAttributeValueTest.php
+++ b/tests/Unit/V2/WorkflowSearchAttributeValueTest.php
@@ -1,0 +1,215 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\V2;
+
+use DateTimeImmutable;
+use Illuminate\Support\Carbon;
+use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Stringable;
+use Workflow\V2\Models\WorkflowSearchAttribute;
+use Workflow\V2\Support\SearchAttributeUpsertService;
+use Workflow\V2\Support\UpsertSearchAttributesCall;
+
+final class WorkflowSearchAttributeValueTest extends TestCase
+{
+    #[DataProvider('inferredTypes')]
+    public function testItInfersThePortableStorageType(mixed $value, string $expected): void
+    {
+        $this->assertSame($expected, WorkflowSearchAttribute::inferType($value));
+    }
+
+    /**
+     * @return iterable<string, array{mixed, string}>
+     */
+    public static function inferredTypes(): iterable
+    {
+        yield 'boolean' => [true, WorkflowSearchAttribute::TYPE_BOOL];
+        yield 'integer' => [42, WorkflowSearchAttribute::TYPE_INT];
+        yield 'float' => [4.2, WorkflowSearchAttribute::TYPE_FLOAT];
+        yield 'carbon datetime' => [Carbon::parse('2026-09-04T12:00:00Z'), WorkflowSearchAttribute::TYPE_DATETIME];
+        yield 'native datetime' => [
+            new DateTimeImmutable('2026-09-04T12:00:00Z'),
+            WorkflowSearchAttribute::TYPE_DATETIME,
+        ];
+        yield 'short identifier' => ['pending', WorkflowSearchAttribute::TYPE_KEYWORD];
+        yield 'prose' => ['waiting for review', WorkflowSearchAttribute::TYPE_STRING];
+        yield 'long text' => [
+            str_repeat('x', WorkflowSearchAttribute::MAX_KEYWORD_LENGTH + 1),
+            WorkflowSearchAttribute::TYPE_STRING,
+        ];
+        yield 'keyword list' => [['php', 'rust'], WorkflowSearchAttribute::TYPE_KEYWORD_LIST];
+        yield 'null deletion marker' => [null, WorkflowSearchAttribute::TYPE_KEYWORD];
+    }
+
+    public function testItRejectsValuesWithoutAPortableStorageType(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Cannot infer search attribute type from value: object');
+
+        WorkflowSearchAttribute::inferType(new \stdClass());
+    }
+
+    #[DataProvider('coercibleValues')]
+    public function testItCoercesDeclaredScalarValues(string $type, mixed $value, mixed $expected): void
+    {
+        $attribute = new WorkflowSearchAttribute();
+        $attribute->setTypedValue($value, $type);
+
+        $this->assertSame($expected, $attribute->getValue());
+    }
+
+    /**
+     * @return iterable<string, array{string, mixed, mixed}>
+     */
+    public static function coercibleValues(): iterable
+    {
+        yield 'null to text' => [WorkflowSearchAttribute::TYPE_STRING, null, ''];
+        yield 'integer to text' => [WorkflowSearchAttribute::TYPE_STRING, 42, '42'];
+        yield 'stringable to keyword' => [
+            WorkflowSearchAttribute::TYPE_KEYWORD,
+            new SearchAttributeStringableValue('customer-42'),
+            'customer-42',
+        ];
+        yield 'numeric string to integer' => [WorkflowSearchAttribute::TYPE_INT, '42', 42];
+        yield 'numeric string to float' => [WorkflowSearchAttribute::TYPE_FLOAT, '4.25', 4.25];
+    }
+
+    #[DataProvider('booleanValues')]
+    public function testItCoercesDocumentedBooleanRepresentations(mixed $value, bool $expected): void
+    {
+        $attribute = new WorkflowSearchAttribute();
+        $attribute->setTypedValue($value, WorkflowSearchAttribute::TYPE_BOOL);
+
+        $this->assertSame($expected, $attribute->getValue());
+    }
+
+    /**
+     * @return iterable<string, array{mixed, bool}>
+     */
+    public static function booleanValues(): iterable
+    {
+        yield 'boolean true' => [true, true];
+        yield 'boolean false' => [false, false];
+        yield 'integer one' => [1, true];
+        yield 'integer non-zero' => [-1, true];
+        yield 'integer zero' => [0, false];
+        yield 'string true' => ['true', true];
+        yield 'string one' => ['1', true];
+        yield 'string yes' => ['yes', true];
+        yield 'string on' => ['on', true];
+        yield 'string false' => ['false', false];
+        yield 'string zero' => ['0', false];
+        yield 'string no' => ['no', false];
+        yield 'string off' => ['off', false];
+        yield 'empty string' => ['', false];
+    }
+
+    public function testItCoercesCarbonAndNativeDatetimes(): void
+    {
+        $carbon = Carbon::parse('2026-09-04T12:00:00.123456Z');
+        $carbonAttribute = new WorkflowSearchAttribute();
+        $carbonAttribute->setTypedValue($carbon, WorkflowSearchAttribute::TYPE_DATETIME);
+
+        $nativeAttribute = new WorkflowSearchAttribute();
+        $nativeAttribute->setTypedValue(
+            new DateTimeImmutable('2026-09-04T13:00:00.654321Z'),
+            WorkflowSearchAttribute::TYPE_DATETIME,
+        );
+
+        $this->assertSame('2026-09-04 12:00:00.123456', $carbonAttribute->getValue()?->format('Y-m-d H:i:s.u'));
+        $this->assertSame('2026-09-04 13:00:00.654321', $nativeAttribute->getValue()?->format('Y-m-d H:i:s.u'));
+    }
+
+    public function testItRejectsAnInvalidDeclaredType(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid search attribute type: uuid');
+
+        (new WorkflowSearchAttribute())->setTypedValue('customer-42', 'uuid');
+    }
+
+    #[DataProvider('unsupportedDeclaredTypes')]
+    public function testItRejectsUnsupportedDeclaredStorageTypes(mixed $type, string $description): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage("Search attribute [customer] declares unsupported type [{$description}]");
+
+        SearchAttributeUpsertService::assertDeclaredTypesCompatible(
+            new UpsertSearchAttributesCall([
+                'customer' => 'customer-42',
+            ]),
+            [
+                'customer' => $type,
+            ],
+        );
+    }
+
+    /**
+     * @return iterable<string, array{mixed, string}>
+     */
+    public static function unsupportedDeclaredTypes(): iterable
+    {
+        yield 'unknown scalar type' => ['uuid', 'uuid'];
+        yield 'non-scalar type' => [['keyword'], 'array'];
+    }
+
+    #[DataProvider('invalidTypedValues')]
+    public function testItRejectsInvalidTypedValuesWithoutPhpConversionWarnings(
+        string $type,
+        mixed $value,
+        string $message,
+    ): void {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage($message);
+
+        (new WorkflowSearchAttribute())->setTypedValue($value, $type);
+    }
+
+    /**
+     * @return iterable<string, array{string, mixed, string}>
+     */
+    public static function invalidTypedValues(): iterable
+    {
+        yield 'keyword list member' => [
+            WorkflowSearchAttribute::TYPE_KEYWORD_LIST,
+            ['php', 42],
+            'keyword_list entries must be strings',
+        ];
+        yield 'keyword list member length' => [
+            WorkflowSearchAttribute::TYPE_KEYWORD_LIST,
+            [str_repeat('x', WorkflowSearchAttribute::MAX_KEYWORD_LENGTH + 1)],
+            'keyword_list entry exceeds maximum length',
+        ];
+        yield 'integer array' => [WorkflowSearchAttribute::TYPE_INT, [], 'Cannot coerce value to int: array'];
+        yield 'float array' => [WorkflowSearchAttribute::TYPE_FLOAT, [], 'Cannot coerce value to float: array'];
+        yield 'boolean array' => [WorkflowSearchAttribute::TYPE_BOOL, [], 'Cannot coerce value to bool: array'];
+        yield 'invalid datetime text' => [
+            WorkflowSearchAttribute::TYPE_DATETIME,
+            'not-a-datetime',
+            'Cannot parse datetime value: not-a-datetime',
+        ];
+        yield 'datetime array' => [
+            WorkflowSearchAttribute::TYPE_DATETIME,
+            [],
+            'Cannot coerce value to datetime: array',
+        ];
+        yield 'string array' => [WorkflowSearchAttribute::TYPE_STRING, [], 'Cannot coerce value to string: array'];
+    }
+}
+
+final readonly class SearchAttributeStringableValue implements Stringable
+{
+    public function __construct(
+        private string $value
+    ) {
+    }
+
+    public function __toString(): string
+    {
+        return $this->value;
+    }
+}


### PR DESCRIPTION
Closes part of #426.

## What changed
- cover typed search-attribute inference, coercion, invalid inputs, relations, deletion, and persisted aggregate limits
- prove oversized multi-attribute upserts roll back atomically
- cover visibility request parsing, version diagnostics, integer booleans, and archived terminal filtering
- report unsupported array/object coercions without PHP conversion warnings

## Validation
- `WorkflowSearchAttributeValueTest`: 42 tests, 55 assertions
- PostgreSQL/Redis-backed `SearchAttributeTest` + `VisibilityFiltersTest`: 51 tests, 257 assertions
- ECS on changed files
- PHPStan on changed production and test surfaces
- `git diff --check`