### PR TITLE
Release Workflow 2.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+## 2.0.4 - 2026-09-06
+
+- Durable `finally` cleanup survives ordinary workflow-task suspension and
+  discarded replay Fibers. Cleanup activities, timers, and memo writes retain
+  normal success/failure replay behavior without running during local teardown.
+
 ## 2.0.3 - 2026-09-02
 
 - Schedule ticks share bounded due-work and buffered-drain batches across

--- a/composer.json
+++ b/composer.json
@@ -79,7 +79,7 @@
             "dev-main": "2.0.x-dev"
         },
         "durable-workflow": {
-            "product-train": "2.0.3",
+            "product-train": "2.0.4",
             "laravel-embedded-upgrade-contract": "resources/laravel-embedded-upgrade-contract.json",
             "laravel-dependency-security-policy": "resources/laravel-dependency-security-policy.json"
         },


### PR DESCRIPTION
Prepare the patch release containing #481 for #480. Only the machine-owned product version changes.

The fix has passed PR CI; the full main matrix is running at b213261f. Publish 2.0.4 after that matrix and this PR's required checks pass, then verify Packagist and the published Laravel upgrade journeys. Keep #480 open until the installable package is verified.