### PR TITLE
Preserve durable retries across early queue delivery

### DIFF
--- a/src/V2/Jobs/RunActivityTask.php
+++ b/src/V2/Jobs/RunActivityTask.php
@@ -49,7 +49,12 @@ final class RunActivityTask implements ShouldQueue
         [$claim, $releaseIn] = $this->claimTask();
 
         if ($releaseIn !== null) {
-            $this->release($releaseIn);
+            // An early wakeup is not a failed execution or a transport retry.
+            $task = WorkflowTask::query()->find($this->taskId);
+
+            if ($task instanceof WorkflowTask) {
+                TaskDispatcher::dispatch($task);
+            }
 
             return;
         }

--- a/src/V2/Jobs/RunTimerTask.php
+++ b/src/V2/Jobs/RunTimerTask.php
@@ -25,7 +25,6 @@ use Workflow\V2\Support\TaskBackendCapabilities;
 use Workflow\V2\Support\TaskCompatibility;
 use Workflow\V2\Support\TaskDispatcher;
 use Workflow\V2\Support\TimerRecovery;
-use Workflow\V2\Support\TimerTransportChunker;
 use Workflow\V2\Support\WorkerCompatibilityFleet;
 use Workflow\V2\Support\WorkflowTaskLease;
 use Workflow\V2\Support\WorkflowTaskPayload;
@@ -83,10 +82,12 @@ final class RunTimerTask implements ShouldQueue
         [$timerId, $releaseIn] = $this->claimTask();
 
         if ($releaseIn !== null) {
-            $this->release(TimerTransportChunker::cappedReleaseDelay(
-                $releaseIn,
-                is_string($this->connection ?? null) ? $this->connection : null,
-            ));
+            // Relay capped/early wakeups without spending the queue job's failure budget.
+            $task = WorkflowTask::query()->find($this->taskId);
+
+            if ($task instanceof WorkflowTask) {
+                TaskDispatcher::dispatch($task);
+            }
 
             return;
         }

--- a/src/V2/Support/TaskDispatcher.php
+++ b/src/V2/Support/TaskDispatcher.php
@@ -143,9 +143,12 @@ final class TaskDispatcher
         }
 
         if ($task->available_at !== null && $task->available_at->isFuture()) {
+            // Queue backends store second-resolution deadlines. Never round a wakeup down.
+            $availableAt = $task->available_at->copy()
+                ->ceilSecond();
             $effectiveDelay = $task->task_type === TaskType::Timer
-                ? TimerTransportChunker::cappedDispatchDelay($task->available_at, $task->connection)
-                : $task->available_at;
+                ? TimerTransportChunker::cappedDispatchDelay($availableAt, $task->connection)
+                : $availableAt;
 
             $job->delay($effectiveDelay);
         }

--- a/src/V2/Support/TimerTransportChunker.php
+++ b/src/V2/Support/TimerTransportChunker.php
@@ -12,13 +12,12 @@ use Carbon\CarbonInterface;
  * SQS limits initial DelaySeconds to 900. Other drivers may impose similar
  * ceilings. When a timer's fire_at exceeds the queue's max delay, the
  * transport dispatches the task with a capped delay. RunTimerTask detects
- * the early arrival (available_at still in the future) and re-releases
- * with the remaining seconds, repeating until the real fire_at is reached.
+ * the early arrival (available_at still in the future) and dispatches a fresh
+ * job with a capped delay, repeating until the real fire_at is reached.
+ * Each wakeup has its own bounded transport failure budget.
  *
- * ChangeMessageVisibility (used by release()) supports up to 43200 seconds
- * on SQS, so subsequent relay hops can use longer delays than the initial
- * dispatch. For truly long timers (> 12 hours), the relay chain continues
- * with capped release delays.
+ * Release-delay helpers remain available for adapters using
+ * ChangeMessageVisibility, which supports up to 43200 seconds on SQS.
  */
 final class TimerTransportChunker
 {
@@ -90,8 +89,7 @@ final class TimerTransportChunker
     /**
      * Cap a release delay (seconds) to the queue driver's ceiling.
      *
-     * Used by RunTimerTask when it arrives before fire_at and needs
-     * to re-release itself for the remaining duration.
+     * For adapters that re-release a delivery rather than enqueueing a fresh job.
      */
     public static function cappedReleaseDelay(int $seconds, ?string $connection = null): int
     {

--- a/tests/Fixtures/V2/TestFractionalRetryActivity.php
+++ b/tests/Fixtures/V2/TestFractionalRetryActivity.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Fixtures\V2;
+
+use RuntimeException;
+use Workflow\V2\Activity;
+
+final class TestFractionalRetryActivity extends Activity
+{
+    public static int $calls = 0;
+
+    public function handle(int $failures): string
+    {
+        if (++self::$calls <= $failures) {
+            throw new RuntimeException('Retry this activity.');
+        }
+
+        return 'completed';
+    }
+}

--- a/tests/Fixtures/V2/TestFractionalRetryWorkflow.php
+++ b/tests/Fixtures/V2/TestFractionalRetryWorkflow.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Fixtures\V2;
+
+use function Workflow\V2\activity;
+
+use Workflow\V2\Support\ActivityOptions;
+use Workflow\V2\Workflow;
+
+final class TestFractionalRetryWorkflow extends Workflow
+{
+    public function handle(int $failures = 1): string
+    {
+        return activity(
+            TestFractionalRetryActivity::class,
+            new ActivityOptions(maxAttempts: 2, backoff: [1]),
+            $failures,
+        );
+    }
+}

--- a/tests/Unit/V2/DelayedTaskQueueTest.php
+++ b/tests/Unit/V2/DelayedTaskQueueTest.php
@@ -1,0 +1,208 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\V2;
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Queue\Events\JobFailed;
+use Illuminate\Queue\Worker;
+use Illuminate\Queue\WorkerOptions;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Queue;
+use Illuminate\Support\Facades\Schema;
+use RuntimeException;
+use Tests\Fixtures\V2\TestFractionalRetryActivity;
+use Tests\Fixtures\V2\TestFractionalRetryWorkflow;
+use Tests\Fixtures\V2\TestTimerWorkflow;
+use Tests\TestCase;
+use Workflow\V2\Enums\TaskStatus;
+use Workflow\V2\Enums\TaskType;
+use Workflow\V2\Models\ActivityAttempt;
+use Workflow\V2\Models\WorkflowTask;
+use Workflow\V2\WorkflowStub;
+
+final class DelayedTaskQueueTest extends TestCase
+{
+    /**
+     * @var list<JobFailed>
+     */
+    private array $failures = [];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Schema::dropIfExists('jobs');
+        Schema::create('jobs', static function (Blueprint $table): void {
+            $table->bigIncrements('id');
+            $table->string('queue')
+                ->index();
+            $table->longText('payload');
+            $table->unsignedTinyInteger('attempts');
+            $table->unsignedInteger('reserved_at')
+                ->nullable();
+            $table->unsignedInteger('available_at');
+            $table->unsignedInteger('created_at');
+        });
+
+        TestFractionalRetryActivity::$calls = 0;
+        Carbon::setTestNow(Carbon::parse('2026-01-15 12:00:00.500000'));
+        $this->app['events']->listen(JobFailed::class, function (JobFailed $event): void {
+            $this->failures[] = $event;
+        });
+    }
+
+    protected function tearDown(): void
+    {
+        Carbon::setTestNow();
+
+        parent::tearDown();
+    }
+
+    /**
+     * @return array<string, array{string}>
+     */
+    public static function queues(): array
+    {
+        return [
+            'database' => ['database'],
+            'redis' => ['redis'],
+        ];
+    }
+
+    /**
+     * @dataProvider queues
+     */
+    public function testFractionalRetryCompletesWithoutTransportFailure(string $driver): void
+    {
+        $this->configureQueue($driver);
+        $workflow = WorkflowStub::make(TestFractionalRetryWorkflow::class);
+        $workflow->start();
+        $this->runNextJob();
+        $this->runNextJob();
+
+        $this->assertSame(1, TestFractionalRetryActivity::$calls);
+        $task = WorkflowTask::query()->where('task_type', TaskType::Activity)
+            ->where('status', TaskStatus::Ready)->sole();
+        $this->assertSame('12:00:01.500000', $task->available_at->format('H:i:s.u'));
+
+        Carbon::setTestNow(Carbon::parse('2026-01-15 12:00:01.000000'));
+        $this->runNextJob();
+        $this->assertSame(1, TestFractionalRetryActivity::$calls);
+        $this->assertSame(1, $task->fresh()->attempt_count);
+
+        Carbon::setTestNow(Carbon::parse('2026-01-15 12:00:02.000000'));
+        $this->runNextJob();
+        $this->runNextJob();
+
+        $this->assertCount(0, $this->failures);
+        $this->assertTrue($workflow->refresh()->completed());
+        $this->assertSame('completed', $workflow->output());
+        $this->assertSame(2, TestFractionalRetryActivity::$calls);
+        $this->assertSame(2, ActivityAttempt::query()->count());
+        $this->assertSame(0, Queue::connection('delivery-test')->size('delayed-tasks'));
+    }
+
+    public function testEarlyTimerDeliveriesDoNotExhaustTransportAttempts(): void
+    {
+        $this->configureQueue('database');
+        $workflow = WorkflowStub::make(TestTimerWorkflow::class);
+        $workflow->start(1);
+        $this->runNextJob();
+
+        $task = WorkflowTask::query()->where('task_type', TaskType::Timer)->sole();
+
+        // Force repeated early broker delivery without changing the durable deadline.
+        for ($delivery = 0; $delivery < 8; ++$delivery) {
+            DB::table('jobs')->update([
+                'available_at' => now()->getTimestamp(),
+            ]);
+            $this->runNextJob();
+            $this->assertCount(0, $this->failures);
+            $this->assertSame(TaskStatus::Ready, $task->fresh()->status);
+            $this->assertSame(0, $task->fresh()->attempt_count);
+            $this->assertSame(0, (int) DB::table('jobs')->sole()->attempts);
+        }
+
+        Carbon::setTestNow(now()->addSeconds(2));
+        $this->runNextJob();
+        $this->runNextJob();
+        $this->assertTrue($workflow->refresh()->completed());
+        $this->assertSame(1, $task->fresh()->attempt_count);
+        $this->assertCount(0, $this->failures);
+    }
+
+    public function testAnEarlyActivityDeliveryPreservesTheBusinessRetryLimit(): void
+    {
+        $this->configureQueue('database');
+        $workflow = WorkflowStub::make(TestFractionalRetryWorkflow::class);
+        $workflow->start(2);
+        $this->runNextJob();
+        $this->runNextJob();
+
+        DB::table('jobs')->update([
+            'available_at' => now()->getTimestamp(),
+        ]);
+        $this->runNextJob();
+        $this->assertSame(1, TestFractionalRetryActivity::$calls);
+        $this->assertSame(0, (int) DB::table('jobs')->sole()->attempts);
+
+        Carbon::setTestNow(now()->addSeconds(2));
+        $this->runNextJob();
+        $this->runNextJob();
+        $this->assertTrue($workflow->refresh()->failed());
+        $this->assertSame(2, TestFractionalRetryActivity::$calls);
+        $this->assertSame(2, ActivityAttempt::query()->count());
+        $this->assertCount(0, $this->failures);
+    }
+
+    public function testInfrastructureFailureStillExhaustsTheActivityTransportBudget(): void
+    {
+        $this->configureQueue('database');
+        $workflow = WorkflowStub::make(TestFractionalRetryWorkflow::class);
+        $workflow->start();
+        $this->runNextJob();
+        $this->app->offsetUnset(TestFractionalRetryActivity::class);
+        $this->app->bind(TestFractionalRetryActivity::class, static function (): never {
+            throw new RuntimeException('Activity container resolution failed.');
+        });
+        $this->runNextJob();
+
+        $this->assertCount(1, $this->failures);
+        $this->assertSame('Activity container resolution failed.', $this->failures[0]->exception->getMessage());
+        $this->assertSame(1, $this->failures[0]->job->attempts());
+        $this->assertSame(0, TestFractionalRetryActivity::$calls);
+        $this->assertSame(0, DB::table('jobs')->count());
+    }
+
+    private function configureQueue(string $driver): void
+    {
+        config([
+            'workflows.v2.connection' => 'delivery-test',
+            'workflows.v2.queue' => 'delayed-tasks',
+            'queue.default' => 'delivery-test',
+            'queue.connections.delivery-test' => $driver === 'database' ? [
+                'driver' => 'database',
+                'connection' => config('database.default'),
+                'table' => 'jobs',
+                'queue' => 'delayed-tasks',
+                'retry_after' => 60,
+            ] : [
+                'driver' => 'redis',
+                'connection' => 'default',
+                'queue' => 'delayed-tasks',
+                'retry_after' => 60,
+                'block_for' => null,
+            ],
+        ]);
+    }
+
+    private function runNextJob(): void
+    {
+        /** @var Worker $worker */
+        $worker = $this->app->make('queue.worker');
+        $worker->runNextJob('delivery-test', 'delayed-tasks', new WorkerOptions(sleep: 0));
+    }
+}

--- a/tests/Unit/V2/DelayedTaskQueueTest.php
+++ b/tests/Unit/V2/DelayedTaskQueueTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Unit\V2;
 
+use Illuminate\Contracts\Bus\Dispatcher;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Queue\Events\JobFailed;
 use Illuminate\Queue\Worker;
@@ -19,6 +20,7 @@ use Tests\Fixtures\V2\TestTimerWorkflow;
 use Tests\TestCase;
 use Workflow\V2\Enums\TaskStatus;
 use Workflow\V2\Enums\TaskType;
+use Workflow\V2\Jobs\RunActivityTask;
 use Workflow\V2\Models\ActivityAttempt;
 use Workflow\V2\Models\WorkflowTask;
 use Workflow\V2\WorkflowStub;
@@ -103,6 +105,15 @@ final class DelayedTaskQueueTest extends TestCase
         $this->assertSame(2, TestFractionalRetryActivity::$calls);
         $this->assertSame(2, ActivityAttempt::query()->count());
         $this->assertSame(0, Queue::connection('delivery-test')->size('delayed-tasks'));
+
+        $duplicate = (new RunActivityTask($task->id))
+            ->onConnection('delivery-test')
+            ->onQueue('delayed-tasks');
+        $this->app->make(Dispatcher::class)->dispatch($duplicate);
+        $this->runNextJob();
+        $this->assertSame(2, TestFractionalRetryActivity::$calls);
+        $this->assertSame(2, ActivityAttempt::query()->count());
+        $this->assertCount(0, $this->failures);
     }
 
     public function testEarlyTimerDeliveriesDoNotExhaustTransportAttempts(): void
@@ -117,7 +128,8 @@ final class DelayedTaskQueueTest extends TestCase
         // Force repeated early broker delivery without changing the durable deadline.
         for ($delivery = 0; $delivery < 8; ++$delivery) {
             DB::table('jobs')->update([
-                'available_at' => now()->getTimestamp(),
+                'available_at' => now()
+                    ->getTimestamp(),
             ]);
             $this->runNextJob();
             $this->assertCount(0, $this->failures);
@@ -143,7 +155,8 @@ final class DelayedTaskQueueTest extends TestCase
         $this->runNextJob();
 
         DB::table('jobs')->update([
-            'available_at' => now()->getTimestamp(),
+            'available_at' => now()
+                ->getTimestamp(),
         ]);
         $this->runNextJob();
         $this->assertSame(1, TestFractionalRetryActivity::$calls);

--- a/tests/Unit/V2/DelayedTaskQueueTest.php
+++ b/tests/Unit/V2/DelayedTaskQueueTest.php
@@ -10,9 +10,12 @@ use Illuminate\Queue\Events\JobFailed;
 use Illuminate\Queue\Worker;
 use Illuminate\Queue\WorkerOptions;
 use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Queue;
 use Illuminate\Support\Facades\Schema;
+use PHPUnit\Framework\Attributes\DataProvider;
 use RuntimeException;
 use Tests\Fixtures\V2\TestFractionalRetryActivity;
 use Tests\Fixtures\V2\TestFractionalRetryWorkflow;
@@ -23,6 +26,7 @@ use Workflow\V2\Enums\TaskType;
 use Workflow\V2\Jobs\RunActivityTask;
 use Workflow\V2\Models\ActivityAttempt;
 use Workflow\V2\Models\WorkflowTask;
+use Workflow\V2\TaskWatchdog;
 use Workflow\V2\WorkflowStub;
 
 final class DelayedTaskQueueTest extends TestCase
@@ -74,9 +78,7 @@ final class DelayedTaskQueueTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider queues
-     */
+    #[DataProvider('queues')]
     public function testFractionalRetryCompletesWithoutTransportFailure(string $driver): void
     {
         $this->configureQueue($driver);
@@ -143,6 +145,37 @@ final class DelayedTaskQueueTest extends TestCase
         $this->runNextJob();
         $this->assertTrue($workflow->refresh()->completed());
         $this->assertSame(1, $task->fresh()->attempt_count);
+        $this->assertCount(0, $this->failures);
+    }
+
+    public function testQueueWorkCommandCompletesTheFractionalRetryWithoutWatchdogRepair(): void
+    {
+        $this->configureQueue('database');
+        Cache::forever(TaskWatchdog::LOOP_THROTTLE_KEY, true);
+        Cache::forever('workflow:watchdog:looping', true);
+        $workflow = WorkflowStub::make(TestFractionalRetryWorkflow::class);
+        $workflow->start();
+
+        foreach (['12:00:00.500000', '12:00:01.000000', '12:00:02.000000'] as $time) {
+            Carbon::setTestNow(Carbon::parse('2026-01-15 ' . $time));
+            $this->assertSame(0, Artisan::call('queue:work', [
+                'connection' => 'delivery-test',
+                '--queue' => 'delayed-tasks',
+                '--stop-when-empty' => true,
+                '--sleep' => 0,
+                '--memory' => 512,
+            ]));
+
+            if ($time !== '12:00:02.000000') {
+                $this->assertSame(1, TestFractionalRetryActivity::$calls);
+                $this->assertFalse($workflow->refresh()->completed());
+            }
+        }
+
+        $this->assertTrue($workflow->refresh()->completed());
+        $this->assertSame('completed', $workflow->output());
+        $this->assertSame(2, TestFractionalRetryActivity::$calls);
+        $this->assertSame(2, ActivityAttempt::query()->count());
         $this->assertCount(0, $this->failures);
     }
 


### PR DESCRIPTION
Addresses #484.

The real Laravel worker regression reproduced the fractional-second activity retry failure on both database and Redis queues. This change rounds only the transport wakeup up to whole seconds and redispatches early activity/timer wakeups through the existing TaskDispatcher as fresh queue jobs. Durable deadlines, task identity, activity maxAttempts, and queue failure budgets remain unchanged.

Focused coverage includes natural fractional retry, duplicate activity delivery, repeated early timer delivery, retry exhaustion, and a real container-resolution failure. No queue fake is used for these paths. SQS timer relays now use capped fresh dispatches (at most 900 seconds per hop), avoiding accumulated delivery attempts; this trades extra broker wakeups for reliable long-timer delivery. No new scheduler or retry engine is added.

Validation in progress on this PR. The initial red test commit reproduced four failures; the corrected focused tests pass (14 tests / 83 assertions, including timer cap tests). Broader validation is running against a clean dependency installation because the local ignored lockfile still resolved the older Laravel 10 set. Publication and a confirming consumer run remain required before closing #484.