### PR TITLE
Release Workflow 2.0.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+## 2.0.5 - 2026-09-06
+
+- Early queue delivery no longer exhausts activity or timer transport attempts.
+  Fractional-second wakeups round up without changing durable deadlines;
+  early wakeups use fresh jobs while business retry limits remain unchanged.
+  Long SQS timers relay through capped 900-second dispatches.
+
 ## 2.0.4 - 2026-09-06
 
 - Durable `finally` cleanup survives ordinary workflow-task suspension and

--- a/composer.json
+++ b/composer.json
@@ -79,7 +79,7 @@
             "dev-main": "2.0.x-dev"
         },
         "durable-workflow": {
-            "product-train": "2.0.4",
+            "product-train": "2.0.5",
             "laravel-embedded-upgrade-contract": "resources/laravel-embedded-upgrade-contract.json",
             "laravel-dependency-security-policy": "resources/laravel-dependency-security-policy.json"
         },


### PR DESCRIPTION
Release metadata and changelog for #485 / #484. The fix prevents early activity/timer delivery from exhausting transport attempts, preserves durable deadlines and business retry budgets, and uses capped fresh timer dispatches. No schema or protocol change. Wait for the full main-branch database/coverage and Laravel upgrade checks on a24f8c4f, then merge and publish the new tag. #484 remains open until the published-package reproduction passes.