### PR TITLE
Prepare Workflow 2.0.6 Nexus timeline patch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+## 2.0.6 - 2026-09-08
+
+- Nexus service-call history projects started, completed, failed, and cancelled
+  events without failing workflow-task completion. Timeline entries retain the
+  service-call identity and summarize the operation without exposing its payload.
+
 ## 2.0.5 - 2026-09-06
 
 - Early queue delivery no longer exhausts activity or timer transport attempts.

--- a/composer.json
+++ b/composer.json
@@ -79,7 +79,7 @@
             "dev-main": "2.0.x-dev"
         },
         "durable-workflow": {
-            "product-train": "2.0.5",
+            "product-train": "2.0.6",
             "laravel-embedded-upgrade-contract": "resources/laravel-embedded-upgrade-contract.json",
             "laravel-dependency-security-policy": "resources/laravel-dependency-security-policy.json"
         },


### PR DESCRIPTION
Release metadata and changelog for #487 / #488. The patch projects all four service-call history events without throwing during durable workflow-task completion; it retains the call identity and keeps payloads out of the summary. No schema or protocol change. Full main database, coverage, and Laravel upgrade checks on d25d00ff must pass before publication. Issue #487 remains open until the published package and Server integration are verified.