### PR TITLE
Release Workflow 2.0.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+## 2.0.7 - 2026-09-08
+
+- Activity metadata projections no longer download or decode external arguments
+  and results merely to inspect lifecycle state. Summary, task, wait, and parallel
+  child checks preserve typed history and attempt metadata without payload-sized
+  memory allocations. Explicit decoded activity views retain their existing behavior.
+
 ## 2.0.6 - 2026-09-08
 
 - Nexus service-call history projects started, completed, failed, and cancelled

--- a/composer.json
+++ b/composer.json
@@ -79,7 +79,7 @@
             "dev-main": "2.0.x-dev"
         },
         "durable-workflow": {
-            "product-train": "2.0.6",
+            "product-train": "2.0.7",
             "laravel-embedded-upgrade-contract": "resources/laravel-embedded-upgrade-contract.json",
             "laravel-dependency-security-policy": "resources/laravel-dependency-security-policy.json"
         },


### PR DESCRIPTION
Prepare the patch release for #490, implemented in #491. Only the package product identity and changelog change here.

The implementation passed full source qualification at 9778c546: https://github.com/durable-workflow/workflow/actions/runs/34205502106. MySQL/PostgreSQL/MariaDB Feature suites, Laravel 9-13 upgrade cells, quality, corpus and unit coverage all passed; v2 coverage is 87.32%, above the accepted 86.74% baseline. Unit coverage ran 2,002 tests / 15,048 assertions, with 15 notices and 2 skips.

Actual Server HTTP qualification and cold MySQL/Server recovery passed with this source dependency: https://github.com/durable-workflow/workflow/pull/491#issuecomment-5581970650.

After required PR checks: merge, publish immutable 2.0.7, verify Packagist and published-package upgrade jobs, then update Server #142 to the published dependency. Do not close #490 until publication is verified.