### PR TITLE
feat: allow mariadb as database backend

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -888,13 +888,18 @@ jobs:
           resolve_service redis 6379 "$REDIS_PUBLISHED_PORT" REDIS
         } >> "$GITHUB_ENV"
 
-    - name: Run bounded locking and history regressions on MariaDB 10.5
-      run: >-
-        vendor/bin/phpunit --testdox --testsuite feature
-        --filter
-        '/(testHistoryPayloadPaginatedUsesConfiguredSummaryCountersWithoutHydratingHistory|testHistoryPayloadPaginatedUsesBoundedAggregatesWhenSummaryIsMissingOrStale|testEmbeddedHeartbeatAndTimeoutEnforcementUseOneConcurrentLockOrder)/'
-        tests/Feature/V2/V2WorkflowTaskBridgeTest.php
-        tests/Feature/V2/V2ActivityTimeoutTest.php
+    - name: Run locking, readiness and replay regressions on MariaDB 10.5
+      run: |
+        vendor/bin/phpunit --testdox --testsuite feature \
+          --filter '/(testHistoryPayloadPaginatedUsesConfiguredSummaryCountersWithoutHydratingHistory|testHistoryPayloadPaginatedUsesBoundedAggregatesWhenSummaryIsMissingOrStale|testEmbeddedHeartbeatAndTimeoutEnforcementUseOneConcurrentLockOrder)/' \
+          tests/Feature/V2/V2WorkflowTaskBridgeTest.php \
+          tests/Feature/V2/V2ActivityTimeoutTest.php
+        DB_CONNECTION=mariadb vendor/bin/phpunit --testdox --testsuite feature \
+          --filter '/(testSnapshotSummarizesDurableBacklogRepairCompatibilityAndWorkerFleet|testPublicReplayerCanReplayLiveRun|testPublicReplayerCanReplayHistoryExportBundle|testHistoryPayloadPaginatedUsesConfiguredSummaryCountersWithoutHydratingHistory|testHistoryPayloadPaginatedUsesBoundedAggregatesWhenSummaryIsMissingOrStale|testEmbeddedHeartbeatAndTimeoutEnforcementUseOneConcurrentLockOrder)/' \
+          tests/Feature/V2/V2OperatorMetricsTest.php \
+          tests/Feature/V2/V2WorkflowReplayerTest.php \
+          tests/Feature/V2/V2WorkflowTaskBridgeTest.php \
+          tests/Feature/V2/V2ActivityTimeoutTest.php
       env:
         APP_KEY: base64:i3g6f+dV8FfsIkcxqd7gbiPn2oXk5r00sTmdD6V5utI=
         DB_CONNECTION: mysql

--- a/src/V2/Support/BackendCapabilities.php
+++ b/src/V2/Support/BackendCapabilities.php
@@ -85,7 +85,11 @@ final class BackendCapabilities
             : self::normalize(config(sprintf('database.connections.%s.driver', $connection)));
         $issues = [];
 
-        $driverSupported = is_string($driver) && in_array($driver, ['mysql', 'pgsql', 'sqlite', 'sqlsrv'], true);
+        $driverSupported = is_string($driver) && in_array(
+            $driver,
+            ['mysql', 'mariadb', 'pgsql', 'sqlite', 'sqlsrv'],
+            true
+        );
 
         if ($connection === null || $driver === null) {
             $issues[] = self::issue(

--- a/src/V2/Support/ReadinessContract.php
+++ b/src/V2/Support/ReadinessContract.php
@@ -91,7 +91,7 @@ final class ReadinessContract
             ],
             'backend_capabilities' => [
                 'database' => [
-                    'supported_drivers' => ['mysql', 'pgsql', 'sqlite', 'sqlsrv'],
+                    'supported_drivers' => ['mysql', 'mariadb', 'pgsql', 'sqlite', 'sqlsrv'],
                     'required_capabilities' => ['transactions', 'after_commit_callbacks', 'durable_ordering'],
                     'sqlite_note' => 'SQLite is supported with limited concurrent write safety and no row-lock capability.',
                 ],

--- a/tests/Unit/V2/BackendCapabilitiesTest.php
+++ b/tests/Unit/V2/BackendCapabilitiesTest.php
@@ -89,6 +89,7 @@ final class BackendCapabilitiesTest extends TestCase
             $contract['surfaces']['claim']['authority']
         );
         $this->assertContains('mysql', $contract['backend_capabilities']['database']['supported_drivers']);
+        $this->assertContains('mariadb', $contract['backend_capabilities']['database']['supported_drivers']);
         $this->assertContains('pgsql', $contract['backend_capabilities']['database']['supported_drivers']);
         $this->assertSame(
             'error',
@@ -145,6 +146,24 @@ final class BackendCapabilitiesTest extends TestCase
             'after_commit_callbacks' => false,
             'durable_ordering' => false,
             'row_locks' => false,
+        ], $snapshot['database']['capabilities']);
+    }
+
+    public function testSnapshotSupportsTheMariaDbDriver(): void
+    {
+        config()->set('database.connections.mariadb.driver', 'mariadb');
+
+        $snapshot = BackendCapabilities::snapshot(databaseConnection: 'mariadb');
+
+        $this->assertSame('mariadb', $snapshot['database']['connection']);
+        $this->assertSame('mariadb', $snapshot['database']['driver']);
+        $this->assertTrue($snapshot['database']['supported']);
+        $this->assertNotContains('database_driver_unsupported', array_column($snapshot['issues'], 'code'));
+        $this->assertSame([
+            'transactions' => true,
+            'after_commit_callbacks' => true,
+            'durable_ordering' => true,
+            'row_locks' => true,
         ], $snapshot['database']['capabilities']);
     }
 


### PR DESCRIPTION
## Summary

Allow `mariadb` as a database backend, next to mysql, and others.

## Verification

<!-- List the commands or other evidence used. If a check was not run, explain why it does not apply. -->

- [x] Relevant automated checks pass locally or are covered by CI.
- [x] Behavior changes include focused regression coverage when practical.
- [ ] User-facing or contract changes update the relevant documentation when needed.
- [ ] Replay or payload-codec changes follow the regression-corpus contract when applicable.

## Compatibility

<!-- Note breaking changes, supported-version impacts, migrations, or release considerations when applicable. -->
