### PR TITLE
Release 2.0.10: native MariaDB readiness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+## 2.0.10 - 2026-09-09
+
+- Recognize Laravel's native `mariadb` database driver in backend readiness and
+  capability reporting. MariaDB no longer appears unsupported when configured
+  with its own driver instead of `mysql`. Both driver paths retain real-database
+  locking and history checks; the native driver also exercises readiness and replay.
+
 ## 2.0.9 - 2026-09-09
 
 - Terminal activity timeouts restore their recorded exception type during

--- a/composer.json
+++ b/composer.json
@@ -79,7 +79,7 @@
             "dev-main": "2.0.x-dev"
         },
         "durable-workflow": {
-            "product-train": "2.0.9",
+            "product-train": "2.0.10",
             "laravel-embedded-upgrade-contract": "resources/laravel-embedded-upgrade-contract.json",
             "laravel-dependency-security-policy": "resources/laravel-dependency-security-policy.json"
         },


### PR DESCRIPTION
Prepares the patch release for #500.

- Updates the package train and changelog only.
- Preserves the contributor's implementation and native MariaDB CI coverage.
- Real-database before/after validation is recorded in https://github.com/durable-workflow/workflow/pull/500#issuecomment-5605862770.

Composer validation and diff checks pass. Publish only after required checks and the target-branch matrix pass; then verify the Packagist release and supported Laravel upgrade journeys.