### PR TITLE
Preserve due-schedule timestamp precision

### DIFF
--- a/src/V2/Support/ScheduleManager.php
+++ b/src/V2/Support/ScheduleManager.php
@@ -502,10 +502,12 @@ final class ScheduleManager
         }
 
         // Phase 2: evaluate due schedules.
+        // DateTime query bindings otherwise lose the model's fractional precision.
+        $dueAt = (new WorkflowSchedule())->fromDateTime(now());
         $due = self::fairScheduleBatch(WorkflowSchedule::query()
             ->where('status', ScheduleStatus::Active->value)
             ->whereNotNull('next_fire_at')
-            ->where('next_fire_at', '<=', now()), $limit, 'next_fire_at');
+            ->where('next_fire_at', '<=', $dueAt), $limit, 'next_fire_at');
 
         foreach ($due as $schedule) {
             $occurrenceTime = $schedule->next_fire_at;

--- a/tests/Feature/V2/V2ScheduleTest.php
+++ b/tests/Feature/V2/V2ScheduleTest.php
@@ -389,6 +389,53 @@ final class V2ScheduleTest extends TestCase
         $this->assertSame($dueAt->format('Y-m-d\TH:i:s.uP'), $triggered->payload['occurrence_time']);
     }
 
+    /**
+     * @return array<string, array{string, string, bool}>
+     */
+    public static function tickTimestampBoundaries(): array
+    {
+        return [
+            'exact second' => ['00.000000', '00.000000', true],
+            'exact microsecond' => ['00.500000', '00.500000', true],
+            'past within same second' => ['00.500000', '00.750000', true],
+            'future within same second' => ['00.500000', '00.499999', false],
+        ];
+    }
+
+    #[\PHPUnit\Framework\Attributes\DataProvider('tickTimestampBoundaries')]
+    public function testTickPreservesPersistedTimestampPrecision(string $dueSecond, string $tickSecond, bool $due): void
+    {
+        WorkflowStub::fake();
+        $dueAt = Carbon::parse('2026-01-01 12:00:' . $dueSecond, 'UTC');
+        Carbon::setTestNow(Carbon::parse('2026-01-01 12:00:' . $tickSecond, 'UTC'));
+
+        try {
+            $schedule = ScheduleManager::create(
+                scheduleId: 'precise-tick',
+                workflowClass: TestScheduledWorkflow::class,
+                cronExpression: '* * * * *',
+            );
+            $schedule->forceFill([
+                'next_fire_at' => $dueAt,
+            ])->save();
+            $schedule = WorkflowSchedule::query()->findOrFail($schedule->id);
+            $this->assertSame($dueAt->format('Y-m-d H:i:s.u'), $schedule->next_fire_at->format('Y-m-d H:i:s.u'));
+
+            $results = ScheduleManager::tick();
+
+            $this->assertCount($due ? 1 : 0, $results);
+            if ($due) {
+                $this->assertSame('triggered', $results[0]['outcome']);
+                $this->assertSame($dueAt->format('Y-m-d\TH:i:s.uP'), $results[0]['occurrence_time']);
+                $this->assertNotNull($results[0]['instance_id']);
+                $this->assertSame([], ScheduleManager::tick());
+            }
+            $this->assertSame($due ? 1 : 0, (int) $schedule->refresh()->fires_count);
+        } finally {
+            Carbon::setTestNow();
+        }
+    }
+
     public function testTickSharesABoundedBatchAcrossNamespaces(): void
     {
         WorkflowStub::fake();


### PR DESCRIPTION
## Summary

Refs #505. Preserve the `WorkflowSchedule` model's microsecond serialization in the due-schedule predicate, instead of letting the connection format a DateTime binding at whole-second precision. No API, schema, cron or overlap-policy change.

The regression persists and reloads the deadline, freezes time at exact whole-second/fractional boundaries, checks original occurrence identity, forbids early dispatch and verifies that a repeated tick does not start twice. Existing fairness checks are unchanged.

## Validation

- Before the fix: three due boundary cases fail on SQLite; the future case passes.
- After the fix: all seven tick cases pass, 36 assertions, PHP 8.4 / Laravel 13 / SQLite.
- ECS applied to the two changed files; diff reviewed.
- Broader schedule/degraded-mode/command tests and static analysis are running. Repository CI will provide normal MySQL and release-gate checks.

## Release Follow-Through

Keep #505 open until publication and affected-consumer qualification. Inspect Server's locked Workflow/image contents and embedded consumers; SDK/CLI protocol and packages are unchanged. Run the published schedule cases on SQLite/MySQL/PostgreSQL after publication; record downstream rebuild/release decisions rather than assuming a library tag changes existing images.