### PR TITLE
Release scheduler precision fix as 2.0.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+## 2.0.12 - 2026-09-10
+
+- Preserve fractional timestamp precision when selecting due schedules. SQLite
+  schedules now dispatch during their original due second instead of waiting
+  for a later tick; fractional deadlines remain exact on supported databases.
+  Future deadlines are not dispatched early, and repeated ticks preserve the
+  original occurrence identity without starting it twice.
+
 ## 2.0.11 - 2026-09-09
 
 - Preserve activity deadlines after an expired worker lease is repaired.

--- a/composer.json
+++ b/composer.json
@@ -79,7 +79,7 @@
             "dev-main": "2.0.x-dev"
         },
         "durable-workflow": {
-            "product-train": "2.0.11",
+            "product-train": "2.0.12",
             "laravel-embedded-upgrade-contract": "resources/laravel-embedded-upgrade-contract.json",
             "laravel-dependency-security-policy": "resources/laravel-dependency-security-policy.json"
         },


### PR DESCRIPTION
## Purpose
Complete the release metadata for #505 / #506. This changes only the package source identity and changelog; the scheduler fix already passed full main CI at 98d9058f.

## Delivery
- Publish an immutable 2.0.12 tag after checks.
- Verify Packagist, the published platform contract and existing Laravel upgrade journeys.
- Run the persisted scheduler boundary regressions against the published package on SQLite, MySQL and PostgreSQL.
- Update Server's exact dependency and publish a new image; refresh Sample App's locked embedded dependency and prepared images.
- Waterline has only a development Workflow dependency, not a bundled runtime. No API/protocol change requires an SDK or CLI release.

Keep #505 open until the required consumer and published-artifact checks are complete.