### PR TITLE
Reduce repeated full-projection lookups during workflow execution

### DIFF
--- a/src/V2/Support/IdempotentProjectionUpsert.php
+++ b/src/V2/Support/IdempotentProjectionUpsert.php
@@ -30,11 +30,33 @@ final class IdempotentProjectionUpsert
      * @param class-string<TModel> $model
      * @param array<string, mixed> $key
      * @param array<string, mixed> $values
+     * @param TModel|null $existing Row loaded by this projection pass, never a cross-task cache.
      * @return TModel
      */
-    public static function upsert(string $model, array $key, array $values): Model
+    public static function upsert(string $model, array $key, array $values, ?Model $existing = null): Model
     {
+        if ($existing !== null) {
+            if (! $existing instanceof $model || ! $existing->exists) {
+                throw new \InvalidArgumentException(
+                    'Prefetched projection must be a persisted instance of the configured model.'
+                );
+            }
+
+            foreach ($key as $column => $value) {
+                if ($existing->getAttribute($column) !== $value) {
+                    throw new \InvalidArgumentException('Prefetched projection must match the upsert key.');
+                }
+            }
+        }
+
         try {
+            if ($existing !== null) {
+                $existing->fill($values)
+                    ->save();
+
+                return $existing;
+            }
+
             /** @var TModel $row */
             $row = $model::query()->updateOrCreate($key, $values);
 

--- a/src/V2/Support/RunSummaryProjector.php
+++ b/src/V2/Support/RunSummaryProjector.php
@@ -399,9 +399,9 @@ final class RunSummaryProjector
             $failureIds,
         );
 
-        RunWaitProjector::project($run);
+        RunWaitProjector::project($run, RunWaitView::forRun($run, $activities, $timers));
         RunTimelineProjector::project($run);
-        RunTimerProjector::project($run);
+        RunTimerProjector::project($run, $timers);
         RunLineageProjector::project($run);
 
         return $summary;

--- a/src/V2/Support/RunTimelineProjector.php
+++ b/src/V2/Support/RunTimelineProjector.php
@@ -23,6 +23,7 @@ final class RunTimelineProjector
     {
         $entries ??= HistoryTimeline::fromHistory($run);
         $entryModel = self::entryModel();
+        $existing = $entryModel::query()->where('workflow_run_id', $run->id)->get()->keyBy('id');
         $seen = [];
         $projected = [];
 
@@ -35,7 +36,14 @@ final class RunTimelineProjector
 
             $projectionId = self::projectionId($run->id, $historyEventId);
             $seen[] = $projectionId;
-            $projected[] = self::upsertEntry($run, $entryModel, $projectionId, $historyEventId, $entry);
+            $projected[] = self::upsertEntry(
+                $run,
+                $entryModel,
+                $projectionId,
+                $historyEventId,
+                $entry,
+                $existing->get($projectionId)
+            );
         }
 
         self::historyProjectionMaintenanceRole()
@@ -153,6 +161,7 @@ final class RunTimelineProjector
         string $projectionId,
         string $historyEventId,
         array $entry,
+        ?WorkflowTimelineEntry $existing = null,
     ): WorkflowTimelineEntry {
         /** @var WorkflowTimelineEntry $row */
         $row = IdempotentProjectionUpsert::upsert(
@@ -180,6 +189,7 @@ final class RunTimelineProjector
                 'failure_id' => self::stringValue($entry['failure_id'] ?? null),
                 'payload' => self::normalizedPayload($entry),
             ],
+            $existing,
         );
 
         return $row;

--- a/src/V2/Support/RunTimerProjector.php
+++ b/src/V2/Support/RunTimerProjector.php
@@ -24,6 +24,7 @@ final class RunTimerProjector
         $entryModel = self::entryModel();
         $seen = [];
         $projected = [];
+        $existing = $entryModel::query()->where('workflow_run_id', $run->id)->get()->keyBy('id');
 
         foreach (array_values($timers) as $position => $timer) {
             $timerId = self::stringValue($timer['id'] ?? null);
@@ -64,6 +65,7 @@ final class RunTimerProjector
                     'history_unsupported_reason' => self::stringValue($timer['history_unsupported_reason'] ?? null),
                     'payload' => self::normalizedPayload($timer),
                 ],
+                $existing->get($projectionId),
             );
 
             $projected[] = $row;

--- a/src/V2/Support/RunWaitProjector.php
+++ b/src/V2/Support/RunWaitProjector.php
@@ -143,6 +143,7 @@ final class RunWaitProjector
         $waitModel = self::waitModel();
         $seen = [];
         $projected = [];
+        $existing = $waitModel::query()->where('workflow_run_id', $run->id)->get()->keyBy('id');
 
         foreach (array_values($waits) as $position => $wait) {
             $waitId = self::waitId($wait, $position);
@@ -186,6 +187,7 @@ final class RunWaitProjector
                     'history_unsupported_reason' => self::stringValue($wait['history_unsupported_reason'] ?? null),
                     'payload' => $payload,
                 ],
+                $existing->get($projectionId),
             );
 
             $projected[] = $row;

--- a/src/V2/Support/RunWaitView.php
+++ b/src/V2/Support/RunWaitView.php
@@ -17,9 +17,11 @@ use Workflow\V2\Models\WorkflowTask;
 final class RunWaitView
 {
     /**
+     * @param list<array<string, mixed>>|null $activities Metadata already derived for this projection pass.
+     * @param list<array<string, mixed>>|null $timers
      * @return list<array<string, mixed>>
      */
-    public static function forRun(WorkflowRun $run): array
+    public static function forRun(WorkflowRun $run, ?array $activities = null, ?array $timers = null): array
     {
         $run->loadMissing([
             'historyEvents',
@@ -51,7 +53,7 @@ final class RunWaitView
 
         $waits = [];
 
-        foreach (RunActivityView::activitiesForRun($run, decodePayloads: false) as $activity) {
+        foreach ($activities ?? RunActivityView::activitiesForRun($run, decodePayloads: false) as $activity) {
             if (! is_string($activity['id'] ?? null)) {
                 continue;
             }
@@ -62,7 +64,7 @@ final class RunWaitView
         $waits = array_merge($waits, self::conditionWaits($conditionWaits, $taskByTimerId));
         $waits = array_merge($waits, UpdateWaits::forRun($run));
 
-        foreach (RunTimerView::timersForRun($run) as $timer) {
+        foreach ($timers ?? RunTimerView::timersForRun($run) as $timer) {
             if (
                 in_array($timer['id'] ?? null, $conditionTimerIds, true)
                 || ($timer['timer_kind'] ?? null) === 'condition_timeout'

--- a/tests/Unit/V2/IdempotentProjectionUpsertTest.php
+++ b/tests/Unit/V2/IdempotentProjectionUpsertTest.php
@@ -15,6 +15,88 @@ use Workflow\V2\Support\IdempotentProjectionUpsert;
 
 final class IdempotentProjectionUpsertTest extends TestCase
 {
+    public function testPrefetchedRowRetainsModelHooksWithoutAnotherSelect(): void
+    {
+        $run = $this->seedRun();
+        $id = hash('sha256', $run->id . '|prefetched');
+        $row = IdempotentProjectionUpsert::upsert(
+            WorkflowTimelineEntry::class,
+            [
+                'id' => $id,
+            ],
+            $this->timelineAttributes($run, 'prefetched', 'before'),
+        );
+        $calls = 0;
+        WorkflowTimelineEntry::saving(static function (WorkflowTimelineEntry $entry) use ($id, &$calls): void {
+            if ($entry->id === $id) {
+                $calls++;
+            }
+        });
+        $connection = $row->getConnection();
+        $connection->flushQueryLog();
+        $connection->enableQueryLog();
+
+        try {
+            $updated = IdempotentProjectionUpsert::upsert(
+                WorkflowTimelineEntry::class,
+                [
+                    'id' => $id,
+                ],
+                [
+                    'summary' => 'after',
+                ],
+                $row,
+            );
+            $queries = $connection->getQueryLog();
+        } finally {
+            $connection->disableQueryLog();
+            WorkflowTimelineEntry::flushEventListeners();
+        }
+
+        $this->assertSame($row, $updated);
+        $this->assertSame(1, $calls);
+        $this->assertSame('after', $row->fresh()->summary);
+        $this->assertCount(0, array_filter($queries, static fn (array $query): bool =>
+            str_starts_with(strtolower($query['query']), 'select')));
+    }
+
+    public function testRejectsPrefetchedRowWithDifferentIdentity(): void
+    {
+        $run = $this->seedRun();
+        $row = IdempotentProjectionUpsert::upsert(
+            WorkflowTimelineEntry::class,
+            [
+                'id' => hash('sha256', 'original'),
+            ],
+            $this->timelineAttributes($run, 'prefetched', 'original'),
+        );
+
+        $this->expectException(\InvalidArgumentException::class);
+        IdempotentProjectionUpsert::upsert(
+            WorkflowTimelineEntry::class,
+            [
+                'id' => hash('sha256', 'different'),
+            ],
+            [
+                'summary' => 'must not write',
+            ],
+            $row,
+        );
+    }
+
+    public function testRejectsUnpersistedPrefetchedRow(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        IdempotentProjectionUpsert::upsert(
+            WorkflowTimelineEntry::class,
+            [
+                'id' => hash('sha256', 'unpersisted'),
+            ],
+            [],
+            new WorkflowTimelineEntry(),
+        );
+    }
+
     public function testInsertsRowWhenNoConflictExists(): void
     {
         $run = $this->seedRun();

--- a/tests/Unit/V2/ProjectionPrefetchTest.php
+++ b/tests/Unit/V2/ProjectionPrefetchTest.php
@@ -1,0 +1,214 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\V2;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Tests\TestCase;
+use Workflow\V2\Models\WorkflowInstance;
+use Workflow\V2\Models\WorkflowRun;
+use Workflow\V2\Models\WorkflowRunTimerEntry;
+use Workflow\V2\Models\WorkflowRunWait;
+use Workflow\V2\Models\WorkflowTimelineEntry;
+use Workflow\V2\Support\RunTimelineProjector;
+use Workflow\V2\Support\RunTimerProjector;
+use Workflow\V2\Support\RunWaitProjector;
+
+final class ProjectionPrefetchTest extends TestCase
+{
+    /**
+     * @return iterable<string, array{class-string, string}>
+     */
+    public static function projectors(): iterable
+    {
+        yield 'timeline' => [RunTimelineProjector::class, 'history_event_id'];
+        yield 'wait' => [RunWaitProjector::class, 'wait_id'];
+        yield 'timer' => [RunTimerProjector::class, 'timer_id'];
+    }
+
+    /**
+     * @return iterable<string, array{class-string, string, class-string<Model>}>
+     */
+    public static function configuredProjectors(): iterable
+    {
+        yield 'timeline' => [RunTimelineProjector::class, 'run_timeline_entry_model', PrefetchedTimelineEntry::class];
+        yield 'wait' => [RunWaitProjector::class, 'run_wait_model', PrefetchedRunWait::class];
+        yield 'timer' => [RunTimerProjector::class, 'run_timer_entry_model', PrefetchedTimerEntry::class];
+    }
+
+    #[DataProvider('configuredProjectors')]
+    public function testPrefetchUsesConfiguredModelTableAndConnection(
+        string $projector,
+        string $configKey,
+        string $model
+    ): void {
+        $run = $this->seedRun('configured');
+        $entries = $this->entries();
+        $original = $projector::project($run, $entries)[0];
+        config()
+            ->set('database.connections.projection-secondary', [
+                'driver' => 'sqlite',
+                'database' => ':memory:',
+            ]);
+        Schema::connection('projection-secondary')->create('custom_projection_rows', static function (Blueprint $table) use (
+            $original
+        ): void {
+            $table->string('id')
+                ->primary();
+
+            foreach (array_keys($original->getAttributes()) as $column) {
+                if ($column !== 'id') {
+                    $table->text($column)
+                        ->nullable();
+                }
+            }
+        });
+        config()
+            ->set('workflows.v2.' . $configKey, $model);
+
+        try {
+            $created = $projector::project($run->fresh(), $entries)[0];
+            $entries[0]['status'] = 'updated';
+            $updated = $projector::project($run->fresh(), $entries)[0];
+
+            $this->assertInstanceOf($model, $updated);
+            $this->assertSame($created->getKey(), $updated->getKey());
+            $this->assertSame('updated', $updated->fresh()->payload['status']);
+            $this->assertSame('resolved', $original->fresh()->payload['status']);
+            $this->assertSame(
+                count($entries),
+                DB::connection('projection-secondary')->table('custom_projection_rows')->count()
+            );
+            $projector::project($run->fresh(), []);
+            $this->assertSame(0, DB::connection('projection-secondary')->table('custom_projection_rows')->count());
+            $this->assertNotNull($original->fresh());
+        } finally {
+            DB::purge('projection-secondary');
+        }
+    }
+
+    #[DataProvider('projectors')]
+    public function testReprojectionUsesOneScopedReadAndPreservesRows(string $projector, string $identity): void
+    {
+        $run = $this->seedRun('prefetch');
+        $entries = $this->entries();
+        /** @var list<Model> $rows */
+        $rows = $projector::project($run, $entries);
+        $expected = array_map(self::attributes(...), $rows);
+        $connection = $rows[0]->getConnection();
+        $table = $rows[0]->getTable();
+        $connection->flushQueryLog();
+        $connection->enableQueryLog();
+
+        try {
+            $reprojected = $projector::project($run->fresh(), $entries);
+            $queries = $connection->getQueryLog();
+        } finally {
+            $connection->disableQueryLog();
+        }
+
+        $reads = array_filter($queries, static fn (array $query): bool =>
+            str_starts_with(strtolower($query['query']), 'select') && str_contains($query['query'], $table));
+        // One prefetched row set plus the existing stale-cleanup primary-key snapshot.
+        $this->assertCount(2, $reads);
+        $this->assertSame($expected, array_map(self::attributes(...), $reprojected));
+
+        $rows[0]->forceFill([
+            'payload' => [
+                'corrupt' => true,
+            ],
+        ])->save();
+        $rows[1]->delete();
+        $orphan = $rows[2]->replicate();
+        $orphan->forceFill([
+            'id' => hash('sha256', 'orphan'),
+            $identity => 'orphan',
+        ])->save();
+        $otherRun = $this->seedRun('unrelated');
+        $otherRows = $projector::project($otherRun, $entries);
+
+        $repaired = $projector::project($run->fresh(), $entries);
+        $this->assertCount(count($entries), $repaired);
+        $this->assertSame($expected[0]['payload'], $repaired[0]->getRawOriginal('payload'));
+        $this->assertSame($expected[1]['id'], $repaired[1]->getKey());
+        $this->assertNull($orphan->fresh());
+        $this->assertNotNull($otherRows[0]->fresh());
+
+        $this->assertSame([], $projector::project($run->fresh(), []));
+        $this->assertSame(0, $rows[0]->newQuery()->where('workflow_run_id', $run->id)->count());
+        $this->assertSame(count($entries), $otherRows[0]->newQuery()->where('workflow_run_id', $otherRun->id)->count());
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    private function entries(): array
+    {
+        return array_map(static fn (int $sequence): array => [
+            'id' => 'entry-' . $sequence,
+            'sequence' => $sequence,
+            'type' => 'TimerFired',
+            'kind' => 'timer',
+            'status' => 'resolved',
+            'summary' => 'Timer completed.',
+            'recorded_at' => '2026-09-01T12:00:00.123456Z',
+            'opened_at' => '2026-09-01T12:00:00.123456Z',
+            'fire_at' => '2026-09-01T12:00:01.123456Z',
+        ], range(1, 20));
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private static function attributes(Model $row): array
+    {
+        $attributes = $row->getAttributes();
+        ksort($attributes);
+
+        return $attributes;
+    }
+
+    private function seedRun(string $id): WorkflowRun
+    {
+        $instance = WorkflowInstance::query()->create([
+            'id' => $id,
+            'workflow_class' => 'ProjectionWorkflow',
+            'workflow_type' => 'projection.workflow',
+            'namespace' => 'default',
+        ]);
+
+        return WorkflowRun::query()->create([
+            'workflow_instance_id' => $instance->id,
+            'run_number' => 1,
+            'workflow_class' => $instance->workflow_class,
+            'workflow_type' => $instance->workflow_type,
+            'status' => 'waiting',
+        ]);
+    }
+}
+
+final class PrefetchedTimelineEntry extends WorkflowTimelineEntry
+{
+    protected $table = 'custom_projection_rows';
+
+    protected $connection = 'projection-secondary';
+}
+
+final class PrefetchedRunWait extends WorkflowRunWait
+{
+    protected $table = 'custom_projection_rows';
+
+    protected $connection = 'projection-secondary';
+}
+
+final class PrefetchedTimerEntry extends WorkflowRunTimerEntry
+{
+    protected $table = 'custom_projection_rows';
+
+    protected $connection = 'projection-secondary';
+}

--- a/tests/Unit/V2/ProjectionReplayTest.php
+++ b/tests/Unit/V2/ProjectionReplayTest.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\V2;
+
+use Tests\TestCase;
+use Workflow\V2\Activity;
+use function Workflow\V2\activity;
+use function Workflow\V2\all;
+use Workflow\V2\Enums\HistoryEventType;
+use Workflow\V2\Models\WorkflowRun;
+use Workflow\V2\Support\RunActivityView;
+use Workflow\V2\Support\RunSummaryProjector;
+use Workflow\V2\Support\RunTimelineProjector;
+use Workflow\V2\Support\RunTimerProjector;
+use Workflow\V2\Support\RunTimerView;
+use Workflow\V2\Support\RunWaitProjector;
+use Workflow\V2\Support\RunWaitView;
+
+use function Workflow\V2\timer;
+use Workflow\V2\Workflow;
+use Workflow\V2\WorkflowStub;
+
+final class ProjectionReplayTest extends TestCase
+{
+    public function testRepeatedActivityAndTimerRoundsKeepColdProjectionsConsistent(): void
+    {
+        $rounds = 3;
+        $calls = 0;
+        WorkflowStub::mock(ProjectionReplayActivity::class, static function ($context, int $value) use (&$calls): int {
+            $calls++;
+
+            return $value;
+        });
+        $this->freezeTime();
+        $workflow = WorkflowStub::make(ProjectionReplayWorkflow::class, 'projection-replay');
+        $workflow->start($rounds);
+
+        for ($round = 0; $round <= $rounds; $round++) {
+            WorkflowStub::runReadyTasks();
+            $run = WorkflowRun::query()->findOrFail($workflow->runId());
+            $activities = RunActivityView::activitiesForRun($run, decodePayloads: false);
+            $timers = RunTimerView::timersForRun($run);
+
+            $this->assertEquals(
+                RunWaitView::forRun($run->fresh()),
+                RunWaitView::forRun($run, $activities, $timers),
+            );
+            RunSummaryProjector::project($run->fresh());
+            $this->assertFalse(RunTimelineProjector::driftStatusForRun($run->fresh())['stale']);
+            $this->assertFalse(RunWaitProjector::driftStatusForRun($run->fresh())['stale']);
+            $this->assertFalse(RunTimerProjector::driftStatusForRun($run->fresh())['stale']);
+            $this->travel(2)
+                ->seconds();
+        }
+
+        $workflow = WorkflowStub::load('projection-replay');
+        $run = WorkflowRun::query()->findOrFail($workflow->runId());
+        $this->assertTrue($workflow->completed());
+        $this->assertSame($rounds * 3, $calls);
+        $this->assertSame($rounds * 3, $workflow->output());
+        $this->assertSame(
+            $rounds * 3,
+            $run->historyEvents()->where('event_type', HistoryEventType::ActivityCompleted)->count()
+        );
+        $this->assertSame($rounds, $run->historyEvents()->where('event_type', HistoryEventType::TimerFired)->count());
+    }
+}
+
+final class ProjectionReplayWorkflow extends Workflow
+{
+    public function handle(int $rounds): int
+    {
+        $result = 0;
+
+        for ($round = 0; $round < $rounds; $round++) {
+            $result += array_sum(all([
+                static fn (): mixed => activity(ProjectionReplayActivity::class, 1),
+                static fn (): mixed => activity(ProjectionReplayActivity::class, 1),
+                static fn (): mixed => activity(ProjectionReplayActivity::class, 1),
+            ]));
+            timer(1);
+        }
+
+        return $result;
+    }
+}
+
+final class ProjectionReplayActivity extends Activity
+{
+    public function handle(int $value): int
+    {
+        return $value;
+    }
+}

--- a/tests/Unit/V2/ProjectionReplayTest.php
+++ b/tests/Unit/V2/ProjectionReplayTest.php
@@ -62,7 +62,8 @@ final class ProjectionReplayTest extends TestCase
         $this->assertSame($rounds * 3, $workflow->output());
         $this->assertSame(
             $rounds * 3,
-            $run->historyEvents()->where('event_type', HistoryEventType::ActivityCompleted)->count()
+            $run->historyEvents()
+                ->where('event_type', HistoryEventType::ActivityCompleted)->count()
         );
         $this->assertSame($rounds, $run->historyEvents()->where('event_type', HistoryEventType::TimerFired)->count());
     }


### PR DESCRIPTION
## Problem

Relates to #508. Repeated full monitoring projection rereads each existing timeline, wait, and timer row individually. Summary projection also derives activity and timer views more than once in the same pass. A small embedded workflow with three parallel activities followed by a timer per round exposes the growing cost.

## Changes

- Prefetch each run's existing projection rows using the configured model, table, and connection; reuse those Eloquent instances within that pass only.
- Retain casts, model save hooks, duplicate-key recovery, point-delete stale cleanup, and history-based repair. Incremental child/claim projection paths are unchanged.
- Reuse the activity metadata and timer views already computed by full summary projection.
- Add fixed-query-count, unchanged-row/timestamp, repair, unrelated-run, custom-model/connection, and cold-reload workflow regression tests.

No new cache, background projector, schema, durable-history format, or public execution contract.

## Validation

Local PHP 8.4.25 / Laravel 13 source checks:

- 15 focused tests / 98 assertions passed, including cold activity metadata projection without external-payload reads and configured-model/table/secondary-connection cases.
- Full `phpstan analyse src tests` and changed-file ECS passed.
- [Full source CI](https://github.com/durable-workflow/workflow/actions/runs/34635202443) passed at `c59828f4c7be77c6efd078419d0aed548c26c8fe`: unit/coverage, all MySQL and PostgreSQL shards, MariaDB, Laravel 9-13 upgrade checks, regression corpus, contracts, and quality. [PR checks](https://github.com/durable-workflow/workflow/actions/runs/34635182309) also passed.
- Final source review confirmed that prefetch is run-scoped and same-pass only; incremental child/claim paths, configured model connections, duplicate-key handling, and stale point-delete behavior are preserved.

Diagnostic only, not a published capacity benchmark: matched sequential runs on the same host, container limit 1 CPU / 1 GiB, SQLite in memory, fake no-op activity bodies, Workflow 2.0.12 versus this source overlay. Sixteen rounds produced 48 activity completions and 179 history events; both runs completed with the correct output and activity count.

| Measurement | Baseline | Candidate |
| --- | ---: | ---: |
| Total test duration | 83.391 s | 65.224 s |
| Round 15 duration | 10.050 s | 7.929 s |
| Round 15 SQL queries | 5,860 | 1,196 |
| PHP peak allocated memory | 79 MB | 79 MB |

XHProf on a separate three-round baseline attributes about 75% of elapsed profiled time to full summary projection. Profiler overhead is excluded from the timing table. The repository-owned three-round correctness reproduction is `tests/Unit/V2/ProjectionReplayTest.php`; query-count regression is in `ProjectionPrefetchTest.php`.

This is a partial optimization: the remaining history-dependent PHP cost is still material. Keep #508 open until its acceptance criteria, broader correctness checks, and published-consumer follow-through are complete. No claim that this patch alone resolves the full performance problem.

## Before Delivery

- Source checks and review are complete. Publish the patch and verify installed-package behavior before calling it delivered.
- Keep remaining history-dependent work explicit; this patch removes measured redundant work without claiming constant-time full history projection.
- On publication, audit pinned Workflow consumers (including Server) and run affected conformance with published artifacts. Do not release unchanged language SDKs merely to align version numbers.

Current `main` consumer audit: Server requires Workflow `2.0.12` exactly and will need a dependency update and rebuilt release. Sample App's embedded lock is `2.0.12` under `^2.0`, requiring a lock update and first-user verification. Waterline's Workflow dependency is development-only; refresh relevant embedded integration qualification without claiming a runtime package release is necessary. PHP SDK and CLI have no Workflow runtime dependency; there is no portable wire change requiring synchronized SDK releases. Deployment-specific follow-through stays in its owning private record.
