### PR TITLE
Release projection lookup fix as 2.0.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+## 2.0.13 - 2026-09-11
+
+- Reduce repeated database lookups during full timeline, wait, and timer
+  projection, and reuse activity and timer metadata within a summary pass.
+  Existing model hooks, configured tables and connections, duplicate-key
+  recovery, and history-based repair remain intact. This reduces repeated
+  projection overhead without changing durable history or execution semantics.
+
 ## 2.0.12 - 2026-09-10
 
 - Preserve fractional timestamp precision when selecting due schedules. SQLite

--- a/composer.json
+++ b/composer.json
@@ -79,7 +79,7 @@
             "dev-main": "2.0.x-dev"
         },
         "durable-workflow": {
-            "product-train": "2.0.12",
+            "product-train": "2.0.13",
             "laravel-embedded-upgrade-contract": "resources/laravel-embedded-upgrade-contract.json",
             "laravel-dependency-security-policy": "resources/laravel-dependency-security-policy.json"
         },


### PR DESCRIPTION
## Purpose

Prepare the immutable 2.0.13 patch release for #508 / #509. Only source release identity and changelog change here. The product patch passed the full source matrix at `c59828f4c7be77c6efd078419d0aed548c26c8fe` before merging as `2d783ee0c84ef23b1263f22149f4c322e90857f8`.

Full source validation: https://github.com/durable-workflow/workflow/actions/runs/34635202443

## Release Follow-Through

- Publish an immutable 2.0.13 tag after checks.
- Verify Packagist, published platform identity/contracts, and the existing Laravel published upgrade matrix.
- Run the focused projection, configured-connection, metadata, and cold-reload regressions against the installed package.
- Update Server's exact Workflow dependency and publish a rebuilt image; refresh Sample App's embedded lock and first-user qualification.
- Waterline uses Workflow as a development-only integration dependency. PHP SDK and CLI have no Workflow runtime dependency; no portable protocol change requires synchronized language SDK releases.

Keep #508 open until required downstream delivery is verified. Diagnostic improvements in #509 are not production capacity claims, and remaining history-dependent projection cost is explicit.
